### PR TITLE
feat: readme improvements

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -38,7 +38,7 @@ const projects = generatePackages(project, {
   ],
   dir: packagesDir,
   scope: scope,
-  prerelease: 'alpha.1',
+  prerelease: 'alpha.2',
 });
 
 updateReadme(project, projects);

--- a/package.json
+++ b/package.json
@@ -243,6 +243,8 @@
     "ts-node": "^9",
     "typescript": "^4.4.4"
   },
+  "peerDependencies": {},
+  "dependencies": {},
   "bundledDependencies": [],
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -243,8 +243,6 @@
     "ts-node": "^9",
     "typescript": "^4.4.4"
   },
-  "peerDependencies": {},
-  "dependencies": {},
   "bundledDependencies": [],
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@cdk-cloudformation/alexa-ask-skill/README.md
+++ b/packages/@cdk-cloudformation/alexa-ask-skill/README.md
@@ -1,6 +1,32 @@
-# AWS CDK CloudFormation Constructs for Alexa::ASK::Skill
+# @cdk-cloudformation/alexa-ask-skill
 
-Constructs for Alexa::ASK::Skill
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Alexa::ASK::Skill`.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Alexa::ASK::Skill \
+  --publisher-id undefined \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/Alexa-ASK-Skill \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/alexa-ask-skill/README.md
+++ b/packages/@cdk-cloudformation/alexa-ask-skill/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/alexa-ask-skill
+# alexa-ask-skill
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Alexa::ASK::Skill`.
 
@@ -27,6 +27,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Alexa::ASK::Skill`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Falexa-ask-skill).
+* Issues related to `Alexa::ASK::Skill` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/alexa-ask-skill/README.md
+++ b/packages/@cdk-cloudformation/alexa-ask-skill/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/alexa-ask-skill
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Alexa::ASK::Skill`.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Alexa::ASK::Skill`.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 

--- a/packages/@cdk-cloudformation/alexa-ask-skill/package.json
+++ b/packages/@cdk-cloudformation/alexa-ask-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/alexa-ask-skill",
   "description": "Constructs for Alexa::ASK::Skill",
-  "version": "0.0.0-alpha.1",
+  "version": "0.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-enforcer/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-enforcer/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Aqua::Enterprise::Enforcer
+# @cdk-cloudformation/aqua-enterprise-enforcer
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Enforcer` v1.6.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A resource provider for Aqua Enterprise Enforcer.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Aqua::Enterprise::Enforcer \
+  --publisher-id 4f06bc39af5f4b984dd46ad17f10316e6258d9fa \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4f06bc39af5f4b984dd46ad17f10316e6258d9fa/Aqua-Enterprise-Enforcer \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/aquasecurity/aqua-helm.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/aqua-enterprise-enforcer/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-enforcer/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/aqua-enterprise-enforcer
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Enforcer` v1.6.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Enforcer` v1.6.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/aqua-enterprise-enforcer/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-enforcer/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/aqua-enterprise-enforcer
+# aqua-enterprise-enforcer
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Enforcer` v1.6.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 A resource provider for Aqua Enterprise Enforcer.
+
+## References
+
+* [Source](https://github.com/aquasecurity/aqua-helm.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/aquasecurity/aqua-helm.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Aqua::Enterprise::Enforcer`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Faqua-enterprise-enforcer+v1.6.0).
+* Issues related to `Aqua::Enterprise::Enforcer` should be reported to the [publisher](https://github.com/aquasecurity/aqua-helm.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/aqua-enterprise-enforcer/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-enforcer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-enforcer",
   "description": "A resource provider for Aqua Enterprise Enforcer.",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/aqua-enterprise-kubeenforcer
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::KubeEnforcer` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::KubeEnforcer` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Aqua::Enterprise::KubeEnforcer
+# @cdk-cloudformation/aqua-enterprise-kubeenforcer
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::KubeEnforcer` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A resource provider for Aqua Enterprise KubeEnforcer.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Aqua::Enterprise::KubeEnforcer \
+  --publisher-id 4f06bc39af5f4b984dd46ad17f10316e6258d9fa \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4f06bc39af5f4b984dd46ad17f10316e6258d9fa/Aqua-Enterprise-KubeEnforcer \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/aquasecurity/aqua-helm.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/aqua-enterprise-kubeenforcer
+# aqua-enterprise-kubeenforcer
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::KubeEnforcer` v1.1.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 A resource provider for Aqua Enterprise KubeEnforcer.
+
+## References
+
+* [Source](https://github.com/aquasecurity/aqua-helm.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/aquasecurity/aqua-helm.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Aqua::Enterprise::KubeEnforcer`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Faqua-enterprise-kubeenforcer+v1.1.0).
+* Issues related to `Aqua::Enterprise::KubeEnforcer` should be reported to the [publisher](https://github.com/aquasecurity/aqua-helm.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-kubeenforcer",
   "description": "A resource provider for Aqua Enterprise KubeEnforcer.",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-scanner/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-scanner/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/aqua-enterprise-scanner
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Scanner` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Scanner` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/aqua-enterprise-scanner/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-scanner/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Aqua::Enterprise::Scanner
+# @cdk-cloudformation/aqua-enterprise-scanner
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Scanner` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A resource provider for Aqua Enterprise Scanner.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Aqua::Enterprise::Scanner \
+  --publisher-id 4f06bc39af5f4b984dd46ad17f10316e6258d9fa \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4f06bc39af5f4b984dd46ad17f10316e6258d9fa/Aqua-Enterprise-Scanner \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/aquasecurity/aqua-helm.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/aqua-enterprise-scanner/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-scanner/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/aqua-enterprise-scanner
+# aqua-enterprise-scanner
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Scanner` v1.1.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 A resource provider for Aqua Enterprise Scanner.
+
+## References
+
+* [Source](https://github.com/aquasecurity/aqua-helm.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/aquasecurity/aqua-helm.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Aqua::Enterprise::Scanner`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Faqua-enterprise-scanner+v1.1.0).
+* Issues related to `Aqua::Enterprise::Scanner` should be reported to the [publisher](https://github.com/aquasecurity/aqua-helm.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/aqua-enterprise-scanner/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-scanner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-scanner",
   "description": "A resource provider for Aqua Enterprise Scanner.",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-server/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-server/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Aqua::Enterprise::Server
+# @cdk-cloudformation/aqua-enterprise-server
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Server` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A resource provider for Aqua Enterprise Server.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Aqua::Enterprise::Server \
+  --publisher-id 4f06bc39af5f4b984dd46ad17f10316e6258d9fa \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4f06bc39af5f4b984dd46ad17f10316e6258d9fa/Aqua-Enterprise-Server \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/aquasecurity/aqua-helm.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/aqua-enterprise-server/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-server/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/aqua-enterprise-server
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Server` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Server` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/aqua-enterprise-server/README.md
+++ b/packages/@cdk-cloudformation/aqua-enterprise-server/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/aqua-enterprise-server
+# aqua-enterprise-server
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Aqua::Enterprise::Server` v1.0.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 A resource provider for Aqua Enterprise Server.
+
+## References
+
+* [Source](https://github.com/aquasecurity/aqua-helm.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/aquasecurity/aqua-helm.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Aqua::Enterprise::Server`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Faqua-enterprise-server+v1.0.0).
+* Issues related to `Aqua::Enterprise::Server` should be reported to the [publisher](https://github.com/aquasecurity/aqua-helm.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/aqua-enterprise-server/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-server",
   "description": "A resource provider for Aqua Enterprise Server.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-integration/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-integration/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/atlassian-opsgenie-integration
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Integration` v1.0.1.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Integration` v1.0.1.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-integration/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-integration/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Atlassian::Opsgenie::Integration
+# @cdk-cloudformation/atlassian-opsgenie-integration
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Integration` v1.0.1.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Opsgenie Integration Resource definition
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Atlassian::Opsgenie::Integration \
+  --publisher-id 4fb8713ab4ce2587ce74e0559d7661bb6e01e72b \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4fb8713ab4ce2587ce74e0559d7661bb6e01e72b/Atlassian-Opsgenie-Integration \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-integration/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-integration/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/atlassian-opsgenie-integration
+# atlassian-opsgenie-integration
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Integration` v1.0.1.
 
@@ -8,6 +8,10 @@
 ## Description
 
 Opsgenie Integration Resource definition
+
+## References
+
+* [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Atlassian::Opsgenie::Integration`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fatlassian-opsgenie-integration+v1.0.1).
+* Issues related to `Atlassian::Opsgenie::Integration` should be reported to the [publisher](https://github.com/opsgenie/opsgenie-cloudformation-resources).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-integration/package.json
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-integration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/atlassian-opsgenie-integration",
   "description": "Opsgenie Integration Resource definition",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.1-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-team/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-team/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/atlassian-opsgenie-team
+# atlassian-opsgenie-team
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Team` v1.0.1.
 
@@ -8,6 +8,10 @@
 ## Description
 
 Opsgenie Team resource schema
+
+## References
+
+* [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Atlassian::Opsgenie::Team`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fatlassian-opsgenie-team+v1.0.1).
+* Issues related to `Atlassian::Opsgenie::Team` should be reported to the [publisher](https://github.com/opsgenie/opsgenie-cloudformation-resources).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-team/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-team/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Atlassian::Opsgenie::Team
+# @cdk-cloudformation/atlassian-opsgenie-team
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Team` v1.0.1.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Opsgenie Team resource schema
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Atlassian::Opsgenie::Team \
+  --publisher-id 4fb8713ab4ce2587ce74e0559d7661bb6e01e72b \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4fb8713ab4ce2587ce74e0559d7661bb6e01e72b/Atlassian-Opsgenie-Team \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-team/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-team/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/atlassian-opsgenie-team
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Team` v1.0.1.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::Team` v1.0.1.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-team/package.json
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/atlassian-opsgenie-team",
   "description": "Opsgenie Team resource schema",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.1-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-user/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-user/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/atlassian-opsgenie-user
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::User` v1.0.1.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::User` v1.0.1.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-user/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-user/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Atlassian::Opsgenie::User
+# @cdk-cloudformation/atlassian-opsgenie-user
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::User` v1.0.1.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Opsgenie User
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Atlassian::Opsgenie::User \
+  --publisher-id 4fb8713ab4ce2587ce74e0559d7661bb6e01e72b \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/4fb8713ab4ce2587ce74e0559d7661bb6e01e72b/Atlassian-Opsgenie-User \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-user/README.md
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-user/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/atlassian-opsgenie-user
+# atlassian-opsgenie-user
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Atlassian::Opsgenie::User` v1.0.1.
 
@@ -8,6 +8,10 @@
 ## Description
 
 Opsgenie User
+
+## References
+
+* [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/opsgenie/opsgenie-cloudformation-resources)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Atlassian::Opsgenie::User`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fatlassian-opsgenie-user+v1.0.1).
+* Issues related to `Atlassian::Opsgenie::User` should be reported to the [publisher](https://github.com/opsgenie/opsgenie-cloudformation-resources).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-user/package.json
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/atlassian-opsgenie-user",
   "description": "Opsgenie User",
-  "version": "1.0.1-alpha.1",
+  "version": "1.0.1-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module
+# awsqs-checkpoint-cloudguardqs-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::CheckPoint::CloudGuardQS::MODULE` v1.1.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::CheckPoint::CloudGuardQS::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-checkpoint-cloudguardqs-module+v1.1.0).
+* Issues related to `AWSQS::CheckPoint::CloudGuardQS::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for AWSQS::CheckPoint::CloudGuardQS::MODULE
+# @cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::CheckPoint::CloudGuardQS::MODULE` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type AWSQS::CheckPoint::CloudGuardQS::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::CheckPoint::CloudGuardQS::MODULE \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-CheckPoint-CloudGuardQS-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::CheckPoint::CloudGuardQS::MODULE` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::CheckPoint::CloudGuardQS::MODULE` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module",
   "description": "Schema for Module Fragment of type AWSQS::CheckPoint::CloudGuardQS::MODULE",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-ec2-linuxbastionqs-module
+# awsqs-ec2-linuxbastionqs-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::EC2::LinuxBastionQS::MODULE` v1.4.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::EC2::LinuxBastionQS::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-ec2-linuxbastionqs-module+v1.4.0).
+* Issues related to `AWSQS::EC2::LinuxBastionQS::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-ec2-linuxbastionqs-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::EC2::LinuxBastionQS::MODULE` v1.4.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::EC2::LinuxBastionQS::MODULE` v1.4.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for AWSQS::EC2::LinuxBastionQS::MODULE
+# @cdk-cloudformation/awsqs-ec2-linuxbastionqs-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::EC2::LinuxBastionQS::MODULE` v1.4.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type AWSQS::EC2::LinuxBastionQS::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::EC2::LinuxBastionQS::MODULE \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-EC2-LinuxBastionQS-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module",
   "description": "Schema for Module Fragment of type AWSQS::EC2::LinuxBastionQS::MODULE",
-  "version": "1.4.0-alpha.1",
+  "version": "1.4.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-eks-cluster/README.md
+++ b/packages/@cdk-cloudformation/awsqs-eks-cluster/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-eks-cluster
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::EKS::Cluster` v1.12.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::EKS::Cluster` v1.12.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-eks-cluster/README.md
+++ b/packages/@cdk-cloudformation/awsqs-eks-cluster/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for AWSQS::EKS::Cluster
+# @cdk-cloudformation/awsqs-eks-cluster
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::EKS::Cluster` v1.12.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::EKS::Cluster \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-EKS-Cluster \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider/blob/main/README.md)
 * [Source](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-eks-cluster/README.md
+++ b/packages/@cdk-cloudformation/awsqs-eks-cluster/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-eks-cluster
+# awsqs-eks-cluster
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::EKS::Cluster` v1.12.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.
+
+## References
+
+* [Documentation](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider/blob/main/README.md)
+* [Source](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider/blob/main/README.md)
-* [Source](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::EKS::Cluster`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-eks-cluster+v1.12.0).
+* Issues related to `AWSQS::EKS::Cluster` should be reported to the [publisher](https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider/blob/main/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-eks-cluster/package.json
+++ b/packages/@cdk-cloudformation/awsqs-eks-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-eks-cluster",
   "description": "A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
-  "version": "1.12.0-alpha.1",
+  "version": "1.12.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for AWSQS::Iridium::CloudConnectQS::MODULE
+# @cdk-cloudformation/awsqs-iridium-cloudconnectqs-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Iridium::CloudConnectQS::MODULE` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type AWSQS::Iridium::CloudConnectQS::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::Iridium::CloudConnectQS::MODULE \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-Iridium-CloudConnectQS-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-iridium-cloudconnectqs-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Iridium::CloudConnectQS::MODULE` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Iridium::CloudConnectQS::MODULE` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-iridium-cloudconnectqs-module
+# awsqs-iridium-cloudconnectqs-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Iridium::CloudConnectQS::MODULE` v1.1.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::Iridium::CloudConnectQS::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-iridium-cloudconnectqs-module+v1.1.0).
+* Issues related to `AWSQS::Iridium::CloudConnectQS::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module",
   "description": "Schema for Module Fragment of type AWSQS::Iridium::CloudConnectQS::MODULE",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-get/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-get/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for AWSQS::Kubernetes::Get
+# @cdk-cloudformation/awsqs-kubernetes-get
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Get` v1.13.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Fetches data from a kubernetes cluster using jsonpath expressions.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::Kubernetes::Get \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-Kubernetes-Get \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md)
 * [Source](https://github.com/aws-quickstart/quickstart-amazon-eks.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-get/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-get/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-kubernetes-get
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Get` v1.13.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Get` v1.13.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-get/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-get/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-kubernetes-get
+# awsqs-kubernetes-get
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Get` v1.13.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 Fetches data from a kubernetes cluster using jsonpath expressions.
+
+## References
+
+* [Documentation](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md)
+* [Source](https://github.com/aws-quickstart/quickstart-amazon-eks.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md)
-* [Source](https://github.com/aws-quickstart/quickstart-amazon-eks.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::Kubernetes::Get`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-kubernetes-get+v1.13.0).
+* Issues related to `AWSQS::Kubernetes::Get` should be reported to the [publisher](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-get/package.json
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-get/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-kubernetes-get",
   "description": "Fetches data from a kubernetes cluster using jsonpath expressions.",
-  "version": "1.13.0-alpha.1",
+  "version": "1.13.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-helm/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-helm/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-kubernetes-helm
+# awsqs-kubernetes-helm
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Helm` v1.11.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 A resource provider for managing helm.
+
+## References
+
+* [Documentation](https://github.com/aws-quickstart/quickstart-helm-resource-provider/blob/main/README.md)
+* [Source](https://github.com/aws-quickstart/quickstart-helm-resource-provider.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/aws-quickstart/quickstart-helm-resource-provider/blob/main/README.md)
-* [Source](https://github.com/aws-quickstart/quickstart-helm-resource-provider.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::Kubernetes::Helm`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-kubernetes-helm+v1.11.0).
+* Issues related to `AWSQS::Kubernetes::Helm` should be reported to the [publisher](https://github.com/aws-quickstart/quickstart-helm-resource-provider/blob/main/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-helm/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-helm/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-kubernetes-helm
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Helm` v1.11.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Helm` v1.11.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-helm/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-helm/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for AWSQS::Kubernetes::Helm
+# @cdk-cloudformation/awsqs-kubernetes-helm
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Helm` v1.11.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A resource provider for managing helm.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::Kubernetes::Helm \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-Kubernetes-Helm \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/aws-quickstart/quickstart-helm-resource-provider/blob/main/README.md)
 * [Source](https://github.com/aws-quickstart/quickstart-helm-resource-provider.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-helm/package.json
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-kubernetes-helm",
   "description": "A resource provider for managing helm.",
-  "version": "1.11.0-alpha.1",
+  "version": "1.11.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-resource/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-resource/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for AWSQS::Kubernetes::Resource
+# @cdk-cloudformation/awsqs-kubernetes-resource
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Resource` v1.15.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Applys a YAML manifest to the specified Kubernetes cluster
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::Kubernetes::Resource \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-Kubernetes-Resource \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md)
 * [Source](https://github.com/aws-quickstart/quickstart-amazon-eks.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-resource/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-resource/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-kubernetes-resource
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Resource` v1.15.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Resource` v1.15.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-resource/README.md
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-resource/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-kubernetes-resource
+# awsqs-kubernetes-resource
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::Kubernetes::Resource` v1.15.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 Applys a YAML manifest to the specified Kubernetes cluster
+
+## References
+
+* [Documentation](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md)
+* [Source](https://github.com/aws-quickstart/quickstart-amazon-eks.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md)
-* [Source](https://github.com/aws-quickstart/quickstart-amazon-eks.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::Kubernetes::Resource`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-kubernetes-resource+v1.15.0).
+* Issues related to `AWSQS::Kubernetes::Resource` should be reported to the [publisher](https://github.com/aws-quickstart/quickstart-kubernetes-resource-provider/blob/main/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-resource/package.json
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-resource/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-kubernetes-resource",
   "description": "Applys a YAML manifest to the specified Kubernetes cluster",
-  "version": "1.15.0-alpha.1",
+  "version": "1.15.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/awsqs-vpc-vpcqs-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::VPC::VPCQS::MODULE` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::VPC::VPCQS::MODULE` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/awsqs-vpc-vpcqs-module
+# awsqs-vpc-vpcqs-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `AWSQS::VPC::VPCQS::MODULE` v1.1.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `AWSQS::VPC::VPCQS::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fawsqs-vpc-vpcqs-module+v1.1.0).
+* Issues related to `AWSQS::VPC::VPCQS::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/README.md
+++ b/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for AWSQS::VPC::VPCQS::MODULE
+# @cdk-cloudformation/awsqs-vpc-vpcqs-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `AWSQS::VPC::VPCQS::MODULE` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type AWSQS::VPC::VPCQS::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name AWSQS::VPC::VPCQS::MODULE \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/408988dff9e863704bcc72e7e13f8d645cee8311/AWSQS-VPC-VPCQS-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-vpc-vpcqs-module",
   "description": "Schema for Module Fragment of type AWSQS::VPC::VPCQS::MODULE",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-dashboards-dashboard/README.md
+++ b/packages/@cdk-cloudformation/datadog-dashboards-dashboard/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Datadog::Dashboards::Dashboard
+# @cdk-cloudformation/datadog-dashboards-dashboard
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Dashboards::Dashboard` v2.0.2.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Datadog Dashboard 2.0.2
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Datadog::Dashboards::Dashboard \
+  --publisher-id 7171b96e5d207b947eb72ca9ce05247c246de623 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/7171b96e5d207b947eb72ca9ce05247c246de623/Datadog-Dashboards-Dashboard \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/datadog-dashboards-dashboard/README.md
+++ b/packages/@cdk-cloudformation/datadog-dashboards-dashboard/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/datadog-dashboards-dashboard
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Dashboards::Dashboard` v2.0.2.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Dashboards::Dashboard` v2.0.2.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/datadog-dashboards-dashboard/README.md
+++ b/packages/@cdk-cloudformation/datadog-dashboards-dashboard/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/datadog-dashboards-dashboard
+# datadog-dashboards-dashboard
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Dashboards::Dashboard` v2.0.2.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Datadog::Dashboards::Dashboard`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fdatadog-dashboards-dashboard+v2.0.2).
+* Issues related to `Datadog::Dashboards::Dashboard` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/datadog-dashboards-dashboard/package.json
+++ b/packages/@cdk-cloudformation/datadog-dashboards-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-dashboards-dashboard",
   "description": "Datadog Dashboard 2.0.2",
-  "version": "2.0.2-alpha.1",
+  "version": "2.0.2-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-integrations-aws/README.md
+++ b/packages/@cdk-cloudformation/datadog-integrations-aws/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/datadog-integrations-aws
+# datadog-integrations-aws
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Integrations::AWS` v2.1.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Datadog::Integrations::AWS`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fdatadog-integrations-aws+v2.1.0).
+* Issues related to `Datadog::Integrations::AWS` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/datadog-integrations-aws/README.md
+++ b/packages/@cdk-cloudformation/datadog-integrations-aws/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Datadog::Integrations::AWS
+# @cdk-cloudformation/datadog-integrations-aws
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Integrations::AWS` v2.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Datadog AWS Integration 2.1.0
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Datadog::Integrations::AWS \
+  --publisher-id 7171b96e5d207b947eb72ca9ce05247c246de623 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/7171b96e5d207b947eb72ca9ce05247c246de623/Datadog-Integrations-AWS \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/datadog-integrations-aws/README.md
+++ b/packages/@cdk-cloudformation/datadog-integrations-aws/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/datadog-integrations-aws
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Integrations::AWS` v2.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Integrations::AWS` v2.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/datadog-integrations-aws/package.json
+++ b/packages/@cdk-cloudformation/datadog-integrations-aws/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-integrations-aws",
   "description": "Datadog AWS Integration 2.1.0",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-monitors-downtime/README.md
+++ b/packages/@cdk-cloudformation/datadog-monitors-downtime/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Datadog::Monitors::Downtime
+# @cdk-cloudformation/datadog-monitors-downtime
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Monitors::Downtime` v3.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Datadog Monitors Downtime 3.0.0
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Datadog::Monitors::Downtime \
+  --publisher-id 7171b96e5d207b947eb72ca9ce05247c246de623 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/7171b96e5d207b947eb72ca9ce05247c246de623/Datadog-Monitors-Downtime \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/datadog-monitors-downtime/README.md
+++ b/packages/@cdk-cloudformation/datadog-monitors-downtime/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/datadog-monitors-downtime
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Monitors::Downtime` v3.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Monitors::Downtime` v3.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/datadog-monitors-downtime/README.md
+++ b/packages/@cdk-cloudformation/datadog-monitors-downtime/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/datadog-monitors-downtime
+# datadog-monitors-downtime
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Monitors::Downtime` v3.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Datadog::Monitors::Downtime`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fdatadog-monitors-downtime+v3.0.0).
+* Issues related to `Datadog::Monitors::Downtime` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/datadog-monitors-downtime/package.json
+++ b/packages/@cdk-cloudformation/datadog-monitors-downtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-monitors-downtime",
   "description": "Datadog Monitors Downtime 3.0.0",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-monitors-monitor/README.md
+++ b/packages/@cdk-cloudformation/datadog-monitors-monitor/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Datadog::Monitors::Monitor
+# @cdk-cloudformation/datadog-monitors-monitor
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Monitors::Monitor` v4.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Datadog Monitor 4.0.0
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Datadog::Monitors::Monitor \
+  --publisher-id 7171b96e5d207b947eb72ca9ce05247c246de623 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/7171b96e5d207b947eb72ca9ce05247c246de623/Datadog-Monitors-Monitor \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/datadog-monitors-monitor/README.md
+++ b/packages/@cdk-cloudformation/datadog-monitors-monitor/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/datadog-monitors-monitor
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::Monitors::Monitor` v4.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Monitors::Monitor` v4.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/datadog-monitors-monitor/README.md
+++ b/packages/@cdk-cloudformation/datadog-monitors-monitor/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/datadog-monitors-monitor
+# datadog-monitors-monitor
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::Monitors::Monitor` v4.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Datadog::Monitors::Monitor`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fdatadog-monitors-monitor+v4.0.0).
+* Issues related to `Datadog::Monitors::Monitor` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/datadog-monitors-monitor/package.json
+++ b/packages/@cdk-cloudformation/datadog-monitors-monitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-monitors-monitor",
   "description": "Datadog Monitor 4.0.0",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-slos-slo/README.md
+++ b/packages/@cdk-cloudformation/datadog-slos-slo/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Datadog::SLOs::SLO
+# @cdk-cloudformation/datadog-slos-slo
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::SLOs::SLO` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Datadog SLO 1.0.0
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Datadog::SLOs::SLO \
+  --publisher-id 7171b96e5d207b947eb72ca9ce05247c246de623 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/7171b96e5d207b947eb72ca9ce05247c246de623/Datadog-SLOs-SLO \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/datadog-slos-slo/README.md
+++ b/packages/@cdk-cloudformation/datadog-slos-slo/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/datadog-slos-slo
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Datadog::SLOs::SLO` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::SLOs::SLO` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/datadog-slos-slo/README.md
+++ b/packages/@cdk-cloudformation/datadog-slos-slo/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/datadog-slos-slo
+# datadog-slos-slo
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Datadog::SLOs::SLO` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Datadog::SLOs::SLO`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fdatadog-slos-slo+v1.0.0).
+* Issues related to `Datadog::SLOs::SLO` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/datadog-slos-slo/package.json
+++ b/packages/@cdk-cloudformation/datadog-slos-slo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-slos-slo",
   "description": "Datadog SLO 1.0.0",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/README.md
+++ b/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/fireeye-cloudintegrations-cloudwatch
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `FireEye::CloudIntegrations::Cloudwatch` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `FireEye::CloudIntegrations::Cloudwatch` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/README.md
+++ b/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for FireEye::CloudIntegrations::Cloudwatch
+# @cdk-cloudformation/fireeye-cloudintegrations-cloudwatch
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `FireEye::CloudIntegrations::Cloudwatch` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 This Resource Type will create necessary resources in your AWS account to forward cloudwatch logs to FireEye Helix. Visit FireEye Cloud Integration Portal for more info and to generate a pre-populated CloudFormation Template
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name FireEye::CloudIntegrations::Cloudwatch \
+  --publisher-id 264c59dceccf8b8a42e60198f3ba62cb0aa9f0bf \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/264c59dceccf8b8a42e60198f3ba62cb0aa9f0bf/FireEye-CloudIntegrations-Cloudwatch \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/README.md
+++ b/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/fireeye-cloudintegrations-cloudwatch
+# fireeye-cloudintegrations-cloudwatch
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `FireEye::CloudIntegrations::Cloudwatch` v1.1.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `FireEye::CloudIntegrations::Cloudwatch`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ffireeye-cloudintegrations-cloudwatch+v1.1.0).
+* Issues related to `FireEye::CloudIntegrations::Cloudwatch` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/package.json
+++ b/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch",
   "description": "This Resource Type will create necessary resources in your AWS account to forward cloudwatch logs to FireEye Helix. Visit FireEye Cloud Integration Portal for more info and to generate a pre-populated CloudFormation Template",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/generic-database-schema/README.md
+++ b/packages/@cdk-cloudformation/generic-database-schema/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/generic-database-schema
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Generic::Database::Schema` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Generic::Database::Schema` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/generic-database-schema/README.md
+++ b/packages/@cdk-cloudformation/generic-database-schema/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/generic-database-schema
+# generic-database-schema
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Generic::Database::Schema` v1.0.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 Uses the Aurora Data API to execute SQL and enforce a schema within a database cluster. Currently only supports Aurora Postgres.
+
+## References
+
+* [Source](https://github.com/iann0036/cfn-types/tree/master/generic-database-schema)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/iann0036/cfn-types/tree/master/generic-database-schema)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Generic::Database::Schema`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fgeneric-database-schema+v1.0.0).
+* Issues related to `Generic::Database::Schema` should be reported to the [publisher](https://github.com/iann0036/cfn-types/tree/master/generic-database-schema).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/generic-database-schema/README.md
+++ b/packages/@cdk-cloudformation/generic-database-schema/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Generic::Database::Schema
+# @cdk-cloudformation/generic-database-schema
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Generic::Database::Schema` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Uses the Aurora Data API to execute SQL and enforce a schema within a database cluster. Currently only supports Aurora Postgres.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Generic::Database::Schema \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/Generic-Database-Schema \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/iann0036/cfn-types/tree/master/generic-database-schema)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/generic-database-schema/package.json
+++ b/packages/@cdk-cloudformation/generic-database-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/generic-database-schema",
   "description": "Uses the Aurora Data API to execute SQL and enforce a schema within a database cluster. Currently only supports Aurora Postgres.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/generic-transcribe-vocabulary/README.md
+++ b/packages/@cdk-cloudformation/generic-transcribe-vocabulary/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Generic::Transcribe::Vocabulary
+# @cdk-cloudformation/generic-transcribe-vocabulary
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Generic::Transcribe::Vocabulary` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A custom vocabulary that you can use to change the way Amazon Transcribe handles transcription of an audio file.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Generic::Transcribe::Vocabulary \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/Generic-Transcribe-Vocabulary \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/iann0036/cfn-types/tree/master/generic-transcribe-vocabulary)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/generic-transcribe-vocabulary/README.md
+++ b/packages/@cdk-cloudformation/generic-transcribe-vocabulary/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/generic-transcribe-vocabulary
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Generic::Transcribe::Vocabulary` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Generic::Transcribe::Vocabulary` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/generic-transcribe-vocabulary/README.md
+++ b/packages/@cdk-cloudformation/generic-transcribe-vocabulary/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/generic-transcribe-vocabulary
+# generic-transcribe-vocabulary
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Generic::Transcribe::Vocabulary` v1.0.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 A custom vocabulary that you can use to change the way Amazon Transcribe handles transcription of an audio file.
+
+## References
+
+* [Source](https://github.com/iann0036/cfn-types/tree/master/generic-transcribe-vocabulary)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/iann0036/cfn-types/tree/master/generic-transcribe-vocabulary)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Generic::Transcribe::Vocabulary`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fgeneric-transcribe-vocabulary+v1.0.0).
+* Issues related to `Generic::Transcribe::Vocabulary` should be reported to the [publisher](https://github.com/iann0036/cfn-types/tree/master/generic-transcribe-vocabulary).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/generic-transcribe-vocabulary/package.json
+++ b/packages/@cdk-cloudformation/generic-transcribe-vocabulary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/generic-transcribe-vocabulary",
   "description": "A custom vocabulary that you can use to change the way Amazon Transcribe handles transcription of an audio file.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gremlin-agent-helm/README.md
+++ b/packages/@cdk-cloudformation/gremlin-agent-helm/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/gremlin-agent-helm
+# gremlin-agent-helm
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Gremlin::Agent::Helm` v1.0.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 An example resource schema demonstrating some basic constructs and validation rules.
+
+## References
+
+* [Source](https://github.com/arunbhagyanath/qs-sysdig.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/arunbhagyanath/qs-sysdig.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Gremlin::Agent::Helm`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fgremlin-agent-helm+v1.0.0).
+* Issues related to `Gremlin::Agent::Helm` should be reported to the [publisher](https://github.com/arunbhagyanath/qs-sysdig.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/gremlin-agent-helm/README.md
+++ b/packages/@cdk-cloudformation/gremlin-agent-helm/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/gremlin-agent-helm
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Gremlin::Agent::Helm` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Gremlin::Agent::Helm` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/gremlin-agent-helm/README.md
+++ b/packages/@cdk-cloudformation/gremlin-agent-helm/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Gremlin::Agent::Helm
+# @cdk-cloudformation/gremlin-agent-helm
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Gremlin::Agent::Helm` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 An example resource schema demonstrating some basic constructs and validation rules.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Gremlin::Agent::Helm \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/Gremlin-Agent-Helm \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/arunbhagyanath/qs-sysdig.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/gremlin-agent-helm/package.json
+++ b/packages/@cdk-cloudformation/gremlin-agent-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gremlin-agent-helm",
   "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-core-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-core-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Artifactory::Core::MODULE
+# @cdk-cloudformation/jfrog-artifactory-core-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::Core::MODULE` v1.12.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Artifactory::Core::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Artifactory::Core::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Artifactory-Core-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-artifactory-core-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-core-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-artifactory-core-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::Core::MODULE` v1.12.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::Core::MODULE` v1.12.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-artifactory-core-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-core-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-artifactory-core-module
+# jfrog-artifactory-core-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::Core::MODULE` v1.12.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Artifactory::Core::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-artifactory-core-module+v1.12.0).
+* Issues related to `JFrog::Artifactory::Core::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-artifactory-core-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-core-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-core-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::Core::MODULE",
-  "version": "1.12.0-alpha.1",
+  "version": "1.12.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Artifactory::EC2Instance::MODULE
+# @cdk-cloudformation/jfrog-artifactory-ec2instance-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::EC2Instance::MODULE` v1.7.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Artifactory::EC2Instance::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Artifactory::EC2Instance::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Artifactory-EC2Instance-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-artifactory-ec2instance-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::EC2Instance::MODULE` v1.7.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::EC2Instance::MODULE` v1.7.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-artifactory-ec2instance-module
+# jfrog-artifactory-ec2instance-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::EC2Instance::MODULE` v1.7.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Artifactory::EC2Instance::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-artifactory-ec2instance-module+v1.7.0).
+* Issues related to `JFrog::Artifactory::EC2Instance::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-ec2instance-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::EC2Instance::MODULE",
-  "version": "1.7.0-alpha.1",
+  "version": "1.7.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Artifactory::ExistingVpc::MODULE
+# @cdk-cloudformation/jfrog-artifactory-existingvpc-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::ExistingVpc::MODULE` v1.11.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Artifactory::ExistingVpc::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Artifactory::ExistingVpc::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Artifactory-ExistingVpc-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-artifactory-existingvpc-module
+# jfrog-artifactory-existingvpc-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::ExistingVpc::MODULE` v1.11.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Artifactory::ExistingVpc::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-artifactory-existingvpc-module+v1.11.0).
+* Issues related to `JFrog::Artifactory::ExistingVpc::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-artifactory-existingvpc-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::ExistingVpc::MODULE` v1.11.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::ExistingVpc::MODULE` v1.11.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-existingvpc-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::ExistingVpc::MODULE",
-  "version": "1.11.0-alpha.1",
+  "version": "1.11.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-artifactory-newvpc-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::NewVpc::MODULE` v1.8.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::NewVpc::MODULE` v1.8.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-artifactory-newvpc-module
+# jfrog-artifactory-newvpc-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Artifactory::NewVpc::MODULE` v1.8.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Artifactory::NewVpc::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-artifactory-newvpc-module+v1.8.0).
+* Issues related to `JFrog::Artifactory::NewVpc::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Artifactory::NewVpc::MODULE
+# @cdk-cloudformation/jfrog-artifactory-newvpc-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Artifactory::NewVpc::MODULE` v1.8.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Artifactory::NewVpc::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Artifactory::NewVpc::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Artifactory-NewVpc-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-newvpc-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::NewVpc::MODULE",
-  "version": "1.8.0-alpha.1",
+  "version": "1.8.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-linux-bastion-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-linux-bastion-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-linux-bastion-module
+# jfrog-linux-bastion-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Linux::Bastion::MODULE` v1.5.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Linux::Bastion::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-linux-bastion-module+v1.5.0).
+* Issues related to `JFrog::Linux::Bastion::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-linux-bastion-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-linux-bastion-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-linux-bastion-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Linux::Bastion::MODULE` v1.5.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Linux::Bastion::MODULE` v1.5.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-linux-bastion-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-linux-bastion-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Linux::Bastion::MODULE
+# @cdk-cloudformation/jfrog-linux-bastion-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Linux::Bastion::MODULE` v1.5.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Linux::Bastion::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Linux::Bastion::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Linux-Bastion-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-linux-bastion-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-linux-bastion-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-linux-bastion-module",
   "description": "Schema for Module Fragment of type JFrog::Linux::Bastion::MODULE",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Vpc::MultiAz::MODULE
+# @cdk-cloudformation/jfrog-vpc-multiaz-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Vpc::MultiAz::MODULE` v1.6.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Vpc::MultiAz::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Vpc::MultiAz::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Vpc-MultiAz-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-vpc-multiaz-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Vpc::MultiAz::MODULE` v1.6.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Vpc::MultiAz::MODULE` v1.6.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-vpc-multiaz-module
+# jfrog-vpc-multiaz-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Vpc::MultiAz::MODULE` v1.6.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Vpc::MultiAz::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-vpc-multiaz-module+v1.6.0).
+* Issues related to `JFrog::Vpc::MultiAz::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-vpc-multiaz-module",
   "description": "Schema for Module Fragment of type JFrog::Vpc::MultiAz::MODULE",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/jfrog-xray-ec2instance-module
+# jfrog-xray-ec2instance-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Xray::EC2Instance::MODULE` v1.6.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `JFrog::Xray::EC2Instance::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fjfrog-xray-ec2instance-module+v1.6.0).
+* Issues related to `JFrog::Xray::EC2Instance::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for JFrog::Xray::EC2Instance::MODULE
+# @cdk-cloudformation/jfrog-xray-ec2instance-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Xray::EC2Instance::MODULE` v1.6.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type JFrog::Xray::EC2Instance::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name JFrog::Xray::EC2Instance::MODULE \
+  --publisher-id 06ff50c2e47f57b381f874871d9fac41796c9522 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/06ff50c2e47f57b381f874871d9fac41796c9522/JFrog-Xray-EC2Instance-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/README.md
+++ b/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/jfrog-xray-ec2instance-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `JFrog::Xray::EC2Instance::MODULE` v1.6.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `JFrog::Xray::EC2Instance::MODULE` v1.6.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-xray-ec2instance-module",
   "description": "Schema for Module Fragment of type JFrog::Xray::EC2Instance::MODULE",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module
+# logzio-autodeploymentlogzio-cloudwatch-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `logzio::autoDeploymentLogzio::CloudWatch::MODULE` v2.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `logzio::autoDeploymentLogzio::CloudWatch::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Flogzio-autodeploymentlogzio-cloudwatch-module+v2.0.0).
+* Issues related to `logzio::autoDeploymentLogzio::CloudWatch::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for logzio::autoDeploymentLogzio::CloudWatch::MODULE
+# @cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `logzio::autoDeploymentLogzio::CloudWatch::MODULE` v2.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type logzio::autoDeploymentLogzio::CloudWatch::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name logzio::autoDeploymentLogzio::CloudWatch::MODULE \
+  --publisher-id 8a9caf0628707da0ff455be490fd366079c8223e \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/8a9caf0628707da0ff455be490fd366079c8223e/logzio-autoDeploymentLogzio-CloudWatch-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `logzio::autoDeploymentLogzio::CloudWatch::MODULE` v2.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `logzio::autoDeploymentLogzio::CloudWatch::MODULE` v2.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module",
   "description": "Schema for Module Fragment of type logzio::autoDeploymentLogzio::CloudWatch::MODULE",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/logzio-awscostandusage-cur-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Logzio::awsCostAndUsage::cur::MODULE` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Logzio::awsCostAndUsage::cur::MODULE` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Logzio::awsCostAndUsage::cur::MODULE
+# @cdk-cloudformation/logzio-awscostandusage-cur-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Logzio::awsCostAndUsage::cur::MODULE` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type Logzio::awsCostAndUsage::cur::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Logzio::awsCostAndUsage::cur::MODULE \
+  --publisher-id 8a9caf0628707da0ff455be490fd366079c8223e \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/8a9caf0628707da0ff455be490fd366079c8223e/Logzio-awsCostAndUsage-cur-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/logzio-awscostandusage-cur-module
+# logzio-awscostandusage-cur-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Logzio::awsCostAndUsage::cur::MODULE` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Logzio::awsCostAndUsage::cur::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Flogzio-awscostandusage-cur-module+v1.0.0).
+* Issues related to `Logzio::awsCostAndUsage::cur::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-awscostandusage-cur-module",
   "description": "Schema for Module Fragment of type Logzio::awsCostAndUsage::cur::MODULE",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/logzio-awssecurityhub-collector-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `logzio::awsSecurityHub::collector::MODULE` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `logzio::awsSecurityHub::collector::MODULE` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for logzio::awsSecurityHub::collector::MODULE
+# @cdk-cloudformation/logzio-awssecurityhub-collector-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `logzio::awsSecurityHub::collector::MODULE` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type logzio::awsSecurityHub::collector::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name logzio::awsSecurityHub::collector::MODULE \
+  --publisher-id 8a9caf0628707da0ff455be490fd366079c8223e \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/8a9caf0628707da0ff455be490fd366079c8223e/logzio-awsSecurityHub-collector-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/logzio-awssecurityhub-collector-module
+# logzio-awssecurityhub-collector-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `logzio::awsSecurityHub::collector::MODULE` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `logzio::awsSecurityHub::collector::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Flogzio-awssecurityhub-collector-module+v1.0.0).
+* Issues related to `logzio::awsSecurityHub::collector::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-awssecurityhub-collector-module",
   "description": "Schema for Module Fragment of type logzio::awsSecurityHub::collector::MODULE",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Logzio::KinesisShipper::KinesisShipper::MODULE` v1.2.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Logzio::KinesisShipper::KinesisShipper::MODULE` v1.2.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Logzio::KinesisShipper::KinesisShipper::MODULE
+# @cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Logzio::KinesisShipper::KinesisShipper::MODULE` v1.2.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type Logzio::KinesisShipper::KinesisShipper::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Logzio::KinesisShipper::KinesisShipper::MODULE \
+  --publisher-id 8a9caf0628707da0ff455be490fd366079c8223e \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/8a9caf0628707da0ff455be490fd366079c8223e/Logzio-KinesisShipper-KinesisShipper-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module
+# logzio-kinesisshipper-kinesisshipper-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Logzio::KinesisShipper::KinesisShipper::MODULE` v1.2.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Logzio::KinesisShipper::KinesisShipper::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Flogzio-kinesisshipper-kinesisshipper-module+v1.2.0).
+* Issues related to `Logzio::KinesisShipper::KinesisShipper::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module",
   "description": "Schema for Module Fragment of type Logzio::KinesisShipper::KinesisShipper::MODULE",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-myservice-myname-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-myservice-myname-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Logzio::MyService::MyName::MODULE
+# @cdk-cloudformation/logzio-myservice-myname-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Logzio::MyService::MyName::MODULE` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type Logzio::MyService::MyName::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Logzio::MyService::MyName::MODULE \
+  --publisher-id 8a9caf0628707da0ff455be490fd366079c8223e \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/8a9caf0628707da0ff455be490fd366079c8223e/Logzio-MyService-MyName-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/logzio-myservice-myname-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-myservice-myname-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/logzio-myservice-myname-module
+# logzio-myservice-myname-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Logzio::MyService::MyName::MODULE` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Logzio::MyService::MyName::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Flogzio-myservice-myname-module+v1.0.0).
+* Issues related to `Logzio::MyService::MyName::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/logzio-myservice-myname-module/README.md
+++ b/packages/@cdk-cloudformation/logzio-myservice-myname-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/logzio-myservice-myname-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Logzio::MyService::MyName::MODULE` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Logzio::MyService::MyName::MODULE` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/logzio-myservice-myname-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-myservice-myname-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-myservice-myname-module",
   "description": "Schema for Module Fragment of type Logzio::MyService::MyName::MODULE",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/mongodb-atlas-cluster
+# mongodb-atlas-cluster
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Cluster` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `MongoDB::Atlas::Cluster`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fmongodb-atlas-cluster+v1.0.0).
+* Issues related to `MongoDB::Atlas::Cluster` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/mongodb-atlas-cluster
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Cluster` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Cluster` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for MongoDB::Atlas::Cluster
+# @cdk-cloudformation/mongodb-atlas-cluster
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Cluster` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 The cluster resource provides access to your cluster configurations. The resource lets you create, edit and delete clusters. The resource requires your Project ID.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name MongoDB::Atlas::Cluster \
+  --publisher-id bb989456c78c398a858fef18f2ca1bfc1fbba082 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Cluster \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/mongodb-atlas-cluster/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-cluster",
   "description": "The cluster resource provides access to your cluster configurations. The resource lets you create, edit and delete clusters. The resource requires your Project ID.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for MongoDB::Atlas::DatabaseUser
+# @cdk-cloudformation/mongodb-atlas-databaseuser
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::DatabaseUser` v1.3.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 The databaseUsers resource lets you retrieve, create and modify the MongoDB users in your cluster. Each user has a set of roles that provide access to the project?s databases. A user?s roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name MongoDB::Atlas::DatabaseUser \
+  --publisher-id bb989456c78c398a858fef18f2ca1bfc1fbba082 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-DatabaseUser \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/mongodb-atlas-databaseuser
+# mongodb-atlas-databaseuser
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::DatabaseUser` v1.3.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `MongoDB::Atlas::DatabaseUser`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fmongodb-atlas-databaseuser+v1.3.0).
+* Issues related to `MongoDB::Atlas::DatabaseUser` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/mongodb-atlas-databaseuser
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::DatabaseUser` v1.3.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::DatabaseUser` v1.3.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-databaseuser",
   "description": "The databaseUsers resource lets you retrieve, create and modify the MongoDB users in your cluster. Each user has a set of roles that provide access to the project?s databases. A user?s roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for MongoDB::Atlas::NetworkPeering
+# @cdk-cloudformation/mongodb-atlas-networkpeering
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::NetworkPeering` v1.2.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 This resource allows to create, read, update and delete a network peering
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name MongoDB::Atlas::NetworkPeering \
+  --publisher-id bb989456c78c398a858fef18f2ca1bfc1fbba082 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-NetworkPeering \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/mongodb-atlas-networkpeering
+# mongodb-atlas-networkpeering
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::NetworkPeering` v1.2.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `MongoDB::Atlas::NetworkPeering`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fmongodb-atlas-networkpeering+v1.2.0).
+* Issues related to `MongoDB::Atlas::NetworkPeering` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/mongodb-atlas-networkpeering
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::NetworkPeering` v1.2.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::NetworkPeering` v1.2.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-networkpeering",
   "description": "This resource allows to create, read, update and delete a network peering",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/mongodb-atlas-project
+# mongodb-atlas-project
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Project` v1.6.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `MongoDB::Atlas::Project`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fmongodb-atlas-project+v1.6.0).
+* Issues related to `MongoDB::Atlas::Project` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/mongodb-atlas-project
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Project` v1.6.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Project` v1.6.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for MongoDB::Atlas::Project
+# @cdk-cloudformation/mongodb-atlas-project
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::Project` v1.6.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Retrieves or creates projects in any given Atlas organization.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name MongoDB::Atlas::Project \
+  --publisher-id bb989456c78c398a858fef18f2ca1bfc1fbba082 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-Project \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/mongodb-atlas-project/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-project",
   "description": "Retrieves or creates projects in any given Atlas organization.",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/mongodb-atlas-projectipaccesslist
+# mongodb-atlas-projectipaccesslist
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::ProjectIpAccessList` v1.1.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 An example resource schema demonstrating some basic constructs and validation rules.
+
+## References
+
+* [Source](https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `MongoDB::Atlas::ProjectIpAccessList`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fmongodb-atlas-projectipaccesslist+v1.1.0).
+* Issues related to `MongoDB::Atlas::ProjectIpAccessList` should be reported to the [publisher](https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for MongoDB::Atlas::ProjectIpAccessList
+# @cdk-cloudformation/mongodb-atlas-projectipaccesslist
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::ProjectIpAccessList` v1.1.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 An example resource schema demonstrating some basic constructs and validation rules.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name MongoDB::Atlas::ProjectIpAccessList \
+  --publisher-id bb989456c78c398a858fef18f2ca1bfc1fbba082 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/bb989456c78c398a858fef18f2ca1bfc1fbba082/MongoDB-Atlas-ProjectIpAccessList \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/mongodb-atlas-projectipaccesslist
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `MongoDB::Atlas::ProjectIpAccessList` v1.1.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `MongoDB::Atlas::ProjectIpAccessList` v1.1.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-projectipaccesslist",
   "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/registry-test-resource1-module/README.md
+++ b/packages/@cdk-cloudformation/registry-test-resource1-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/registry-test-resource1-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `REGISTRY::TEST::RESOURCE1::MODULE` v1.5.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `REGISTRY::TEST::RESOURCE1::MODULE` v1.5.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/registry-test-resource1-module/README.md
+++ b/packages/@cdk-cloudformation/registry-test-resource1-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/registry-test-resource1-module
+# registry-test-resource1-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `REGISTRY::TEST::RESOURCE1::MODULE` v1.5.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `REGISTRY::TEST::RESOURCE1::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fregistry-test-resource1-module+v1.5.0).
+* Issues related to `REGISTRY::TEST::RESOURCE1::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/registry-test-resource1-module/README.md
+++ b/packages/@cdk-cloudformation/registry-test-resource1-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for REGISTRY::TEST::RESOURCE1::MODULE
+# @cdk-cloudformation/registry-test-resource1-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `REGISTRY::TEST::RESOURCE1::MODULE` v1.5.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type REGISTRY::TEST::RESOURCE::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name REGISTRY::TEST::RESOURCE1::MODULE \
+  --publisher-id 4686b5f994c8b12636b1af16ce88b8e2d2e75c8c \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/4686b5f994c8b12636b1af16ce88b8e2d2e75c8c/REGISTRY-TEST-RESOURCE1-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/registry-test-resource1-module/package.json
+++ b/packages/@cdk-cloudformation/registry-test-resource1-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/registry-test-resource1-module",
   "description": "Schema for Module Fragment of type REGISTRY::TEST::RESOURCE::MODULE",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snyk-container-helm/README.md
+++ b/packages/@cdk-cloudformation/snyk-container-helm/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/snyk-container-helm
+# snyk-container-helm
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Snyk::Container::Helm` v1.2.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 Snyk integrates with Amazon EKS, enabling you to import and test your running workloads and identify vulnerabilities in their associated images and configurations that might make those workloads less secure. Once imported, Snyk continues to monitor those workloads, identifying additional security issues as new images are deployed and the workload configuration changes.
+
+## References
+
+* [Documentation](https://github.com/snyk/aws-cloudformation-resource-providers/blob/main/snyk-container-helm/README.md)
+* [Source](https://github.com/snyk/aws-cloudformation-resource-providers.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/snyk/aws-cloudformation-resource-providers/blob/main/snyk-container-helm/README.md)
-* [Source](https://github.com/snyk/aws-cloudformation-resource-providers.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Snyk::Container::Helm`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fsnyk-container-helm+v1.2.0).
+* Issues related to `Snyk::Container::Helm` should be reported to the [publisher](https://github.com/snyk/aws-cloudformation-resource-providers/blob/main/snyk-container-helm/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/snyk-container-helm/README.md
+++ b/packages/@cdk-cloudformation/snyk-container-helm/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for Snyk::Container::Helm
+# @cdk-cloudformation/snyk-container-helm
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Snyk::Container::Helm` v1.2.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Snyk integrates with Amazon EKS, enabling you to import and test your running workloads and identify vulnerabilities in their associated images and configurations that might make those workloads less secure. Once imported, Snyk continues to monitor those workloads, identifying additional security issues as new images are deployed and the workload configuration changes.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Snyk::Container::Helm \
+  --publisher-id 23b85bc331bd703709e021cd4c874df9f591d746 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/23b85bc331bd703709e021cd4c874df9f591d746/Snyk-Container-Helm \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/snyk/aws-cloudformation-resource-providers/blob/main/snyk-container-helm/README.md)
 * [Source](https://github.com/snyk/aws-cloudformation-resource-providers.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/snyk-container-helm/README.md
+++ b/packages/@cdk-cloudformation/snyk-container-helm/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/snyk-container-helm
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Snyk::Container::Helm` v1.2.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Snyk::Container::Helm` v1.2.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/snyk-container-helm/package.json
+++ b/packages/@cdk-cloudformation/snyk-container-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snyk-container-helm",
   "description": "Snyk integrates with Amazon EKS, enabling you to import and test your running workloads and identify vulnerabilities in their associated images and configurations that might make those workloads less secure. Once imported, Snyk continues to monitor those workloads, identifying additional security issues as new images are deployed and the workload configuration changes.",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/README.md
+++ b/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/splunk-enterprise-quickstart-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Splunk::Enterprise::QuickStart::MODULE` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Splunk::Enterprise::QuickStart::MODULE` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/README.md
+++ b/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/splunk-enterprise-quickstart-module
+# splunk-enterprise-quickstart-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Splunk::Enterprise::QuickStart::MODULE` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Splunk::Enterprise::QuickStart::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fsplunk-enterprise-quickstart-module+v1.0.0).
+* Issues related to `Splunk::Enterprise::QuickStart::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/README.md
+++ b/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Splunk::Enterprise::QuickStart::MODULE
+# @cdk-cloudformation/splunk-enterprise-quickstart-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Splunk::Enterprise::QuickStart::MODULE` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type Splunk::Enterprise::QuickStart::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Splunk::Enterprise::QuickStart::MODULE \
+  --publisher-id c90b10f63c592300fda916a73ffef76788069f34 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/c90b10f63c592300fda916a73ffef76788069f34/Splunk-Enterprise-QuickStart-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/package.json
+++ b/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/splunk-enterprise-quickstart-module",
   "description": "Schema for Module Fragment of type Splunk::Enterprise::QuickStart::MODULE",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/spot-elastigroup-group/README.md
+++ b/packages/@cdk-cloudformation/spot-elastigroup-group/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/spot-elastigroup-group
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Spot::Elastigroup::Group` v1.0.3.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Spot::Elastigroup::Group` v1.0.3.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/spot-elastigroup-group/README.md
+++ b/packages/@cdk-cloudformation/spot-elastigroup-group/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/spot-elastigroup-group
+# spot-elastigroup-group
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Spot::Elastigroup::Group` v1.0.3.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Spot::Elastigroup::Group`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fspot-elastigroup-group+v1.0.3).
+* Issues related to `Spot::Elastigroup::Group` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/spot-elastigroup-group/README.md
+++ b/packages/@cdk-cloudformation/spot-elastigroup-group/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Spot::Elastigroup::Group
+# @cdk-cloudformation/spot-elastigroup-group
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Spot::Elastigroup::Group` v1.0.3.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 The Spot Elastigroup Resource allows you to create, update, manage, and delete Spot Elastigroups easily with CloudFormation
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Spot::Elastigroup::Group \
+  --publisher-id 91d05981c6c0b080f2f1adcb370e1145c39b99e2 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/91d05981c6c0b080f2f1adcb370e1145c39b99e2/Spot-Elastigroup-Group \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/spot-elastigroup-group/package.json
+++ b/packages/@cdk-cloudformation/spot-elastigroup-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/spot-elastigroup-group",
   "description": "The Spot Elastigroup Resource allows you to create, update, manage, and delete Spot Elastigroups easily with CloudFormation",
-  "version": "1.0.3-alpha.1",
+  "version": "1.0.3-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/stackery-open-bastion-module/README.md
+++ b/packages/@cdk-cloudformation/stackery-open-bastion-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/stackery-open-bastion-module
+# stackery-open-bastion-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Stackery::Open::Bastion::MODULE` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Stackery::Open::Bastion::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fstackery-open-bastion-module+v1.0.0).
+* Issues related to `Stackery::Open::Bastion::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/stackery-open-bastion-module/README.md
+++ b/packages/@cdk-cloudformation/stackery-open-bastion-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/stackery-open-bastion-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Stackery::Open::Bastion::MODULE` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Stackery::Open::Bastion::MODULE` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/stackery-open-bastion-module/README.md
+++ b/packages/@cdk-cloudformation/stackery-open-bastion-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Stackery::Open::Bastion::MODULE
+# @cdk-cloudformation/stackery-open-bastion-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Stackery::Open::Bastion::MODULE` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type Stackery::Open::Bastion::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Stackery::Open::Bastion::MODULE \
+  --publisher-id c7a1566696d21e673a0e14208c79edfc9dd639e3 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/c7a1566696d21e673a0e14208c79edfc9dd639e3/Stackery-Open-Bastion-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/stackery-open-bastion-module/package.json
+++ b/packages/@cdk-cloudformation/stackery-open-bastion-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/stackery-open-bastion-module",
   "description": "Schema for Module Fragment of type Stackery::Open::Bastion::MODULE",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/stocks-orders-marketorder/README.md
+++ b/packages/@cdk-cloudformation/stocks-orders-marketorder/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/stocks-orders-marketorder
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Stocks::Orders::MarketOrder` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Stocks::Orders::MarketOrder` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/stocks-orders-marketorder/README.md
+++ b/packages/@cdk-cloudformation/stocks-orders-marketorder/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Stocks::Orders::MarketOrder
+# @cdk-cloudformation/stocks-orders-marketorder
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Stocks::Orders::MarketOrder` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A market order is a request to buy or sell a security at the currently available market price. The order to buy a security will be submitted on resource creation and the security will be sold (or the unfilled order cancelled) on resource deletion. Supported exchanges are AMEX, ARCA, BATS, NYSE, NASDAQ and NYSEARCA.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Stocks::Orders::MarketOrder \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/Stocks-Orders-MarketOrder \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/iann0036/cfn-types/tree/master/stocks-orders-marketorder)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/stocks-orders-marketorder/README.md
+++ b/packages/@cdk-cloudformation/stocks-orders-marketorder/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/stocks-orders-marketorder
+# stocks-orders-marketorder
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Stocks::Orders::MarketOrder` v1.0.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 A market order is a request to buy or sell a security at the currently available market price. The order to buy a security will be submitted on resource creation and the security will be sold (or the unfilled order cancelled) on resource deletion. Supported exchanges are AMEX, ARCA, BATS, NYSE, NASDAQ and NYSEARCA.
+
+## References
+
+* [Source](https://github.com/iann0036/cfn-types/tree/master/stocks-orders-marketorder)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/iann0036/cfn-types/tree/master/stocks-orders-marketorder)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Stocks::Orders::MarketOrder`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fstocks-orders-marketorder+v1.0.0).
+* Issues related to `Stocks::Orders::MarketOrder` should be reported to the [publisher](https://github.com/iann0036/cfn-types/tree/master/stocks-orders-marketorder).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/stocks-orders-marketorder/package.json
+++ b/packages/@cdk-cloudformation/stocks-orders-marketorder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/stocks-orders-marketorder",
   "description": "A market order is a request to buy or sell a security at the currently available market price. The order to buy a security will be submitted on resource creation and the security will be sold (or the unfilled order cancelled) on resource deletion. Supported exchanges are AMEX, ARCA, BATS, NYSE, NASDAQ and NYSEARCA.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/README.md
+++ b/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/README.md
+++ b/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/README.md
@@ -1,6 +1,35 @@
-# AWS CDK CloudFormation Constructs for Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE
+# @cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Schema for Module Fragment of type Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE \
+  --publisher-id bf9c3875bb157d57566fdd0661e23ca05eb62a19 \
+  --type MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/module/bf9c3875bb157d57566fdd0661e23ca05eb62a19/Symphonia-OpenSource-CloudFormationArtifactsBucket-MODULE \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/README.md
+++ b/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module
+# symphonia-opensource-cloudformationartifactsbucket-module
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE` v1.0.0.
 
@@ -30,6 +30,15 @@ aws cloudformation activate-type \
 ```
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
+## Feedback
+
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fsymphonia-opensource-cloudformationartifactsbucket-module+v1.0.0).
+* Issues related to `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE` should be reported to the [publisher](undefined).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/package.json
+++ b/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module",
   "description": "Schema for Module Fragment of type Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/sysdig-helm-agent/README.md
+++ b/packages/@cdk-cloudformation/sysdig-helm-agent/README.md
@@ -1,8 +1,39 @@
-# AWS CDK CloudFormation Constructs for Sysdig::Helm::Agent
+# @cdk-cloudformation/sysdig-helm-agent
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Sysdig::Helm::Agent` v1.8.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Sysdig Agent EKS cluster deployment.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name Sysdig::Helm::Agent \
+  --publisher-id a108ed126706e786484be9f9ab13bf537951db1d \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/a108ed126706e786484be9f9ab13bf537951db1d/Sysdig-Helm-Agent \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Source](https://github.com/sysdiglabs/cloudformation-resource-providers.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/sysdig-helm-agent/README.md
+++ b/packages/@cdk-cloudformation/sysdig-helm-agent/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/sysdig-helm-agent
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `Sysdig::Helm::Agent` v1.8.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Sysdig::Helm::Agent` v1.8.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/sysdig-helm-agent/README.md
+++ b/packages/@cdk-cloudformation/sysdig-helm-agent/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/sysdig-helm-agent
+# sysdig-helm-agent
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `Sysdig::Helm::Agent` v1.8.0.
 
@@ -8,6 +8,10 @@
 ## Description
 
 Sysdig Agent EKS cluster deployment.
+
+## References
+
+* [Source](https://github.com/sysdiglabs/cloudformation-resource-providers.git)
 
 ## Usage
 
@@ -31,9 +35,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Source](https://github.com/sysdiglabs/cloudformation-resource-providers.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `Sysdig::Helm::Agent`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Fsysdig-helm-agent+v1.8.0).
+* Issues related to `Sysdig::Helm::Agent` should be reported to the [publisher](https://github.com/sysdiglabs/cloudformation-resource-providers.git).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/sysdig-helm-agent/package.json
+++ b/packages/@cdk-cloudformation/sysdig-helm-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/sysdig-helm-agent",
   "description": "Sysdig Agent EKS cluster deployment.",
-  "version": "1.8.0-alpha.1",
+  "version": "1.8.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-ad-computer/README.md
+++ b/packages/@cdk-cloudformation/tf-ad-computer/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::AD::Computer
+# @cdk-cloudformation/tf-ad-computer
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AD::Computer` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 CloudFormation equivalent of ad_computer
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AD::Computer \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AD-Computer \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-Computer/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-ad-computer/README.md
+++ b/packages/@cdk-cloudformation/tf-ad-computer/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-ad-computer
+# tf-ad-computer
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AD::Computer` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 CloudFormation equivalent of ad_computer
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-Computer/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-Computer/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AD::Computer`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-ad-computer+v1.0.0).
+* Issues related to `TF::AD::Computer` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-Computer/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-ad-computer/README.md
+++ b/packages/@cdk-cloudformation/tf-ad-computer/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-ad-computer
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AD::Computer` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AD::Computer` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-ad-computer/package.json
+++ b/packages/@cdk-cloudformation/tf-ad-computer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-ad-computer",
   "description": "CloudFormation equivalent of ad_computer",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-ad-user/README.md
+++ b/packages/@cdk-cloudformation/tf-ad-user/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::AD::User
+# @cdk-cloudformation/tf-ad-user
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AD::User` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 CloudFormation equivalent of ad_user
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AD::User \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AD-User \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-User/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-ad-user/README.md
+++ b/packages/@cdk-cloudformation/tf-ad-user/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-ad-user
+# tf-ad-user
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AD::User` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 CloudFormation equivalent of ad_user
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-User/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-User/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AD::User`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-ad-user+v1.0.0).
+* Issues related to `TF::AD::User` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/ad/TF-AD-User/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-ad-user/README.md
+++ b/packages/@cdk-cloudformation/tf-ad-user/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-ad-user
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AD::User` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AD::User` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-ad-user/package.json
+++ b/packages/@cdk-cloudformation/tf-ad-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-ad-user",
   "description": "CloudFormation equivalent of ad_user",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-aws-keypair/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-keypair/README.md
@@ -1,4 +1,10 @@
-# AWS CDK CloudFormation Constructs for TF::AWS::KeyPair
+# @cdk-cloudformation/tf-aws-keypair
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AWS::KeyPair` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Provides an [EC2 key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) resource. A key pair is used to control login access to EC2 instances.
 
@@ -9,9 +15,34 @@ When importing an existing key pair the public key material may be in any format
 * OpenSSH public key format (the format in ~/.ssh/authorized_keys)
 * Base64 encoded DER format
 * SSH public key file format as specified in RFC4716
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AWS::KeyPair \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AWS-KeyPair \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-KeyPair/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-aws-keypair/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-keypair/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-aws-keypair
+# tf-aws-keypair
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AWS::KeyPair` v1.0.0.
 
@@ -16,6 +16,11 @@ When importing an existing key pair the public key material may be in any format
 * OpenSSH public key format (the format in ~/.ssh/authorized_keys)
 * Base64 encoded DER format
 * SSH public key file format as specified in RFC4716
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-KeyPair/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -39,10 +44,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-KeyPair/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AWS::KeyPair`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-aws-keypair+v1.0.0).
+* Issues related to `TF::AWS::KeyPair` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-KeyPair/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-aws-keypair/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-keypair/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-aws-keypair
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AWS::KeyPair` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AWS::KeyPair` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-aws-keypair/package.json
+++ b/packages/@cdk-cloudformation/tf-aws-keypair/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-aws-keypair",
   "description": "Provides an [EC2 key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) resource. A key pair is used to control login access to EC2 instances.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-aws-s3bucket/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucket/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-aws-s3bucket
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AWS::S3Bucket` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AWS::S3Bucket` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-aws-s3bucket/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucket/README.md
@@ -1,11 +1,42 @@
-# AWS CDK CloudFormation Constructs for TF::AWS::S3Bucket
+# @cdk-cloudformation/tf-aws-s3bucket
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AWS::S3Bucket` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Provides a S3 bucket resource.
 
 -> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the [`aws_s3control_bucket`](/docs/providers/aws/r/s3control_bucket.html) resource.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AWS::S3Bucket \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AWS-S3Bucket \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3Bucket/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-aws-s3bucket/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucket/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-aws-s3bucket
+# tf-aws-s3bucket
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AWS::S3Bucket` v1.0.0.
 
@@ -10,6 +10,11 @@
 Provides a S3 bucket resource.
 
 -> This functionality is for managing S3 in an AWS Partition. To manage [S3 on Outposts](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3onOutposts.html), see the [`aws_s3control_bucket`](/docs/providers/aws/r/s3control_bucket.html) resource.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3Bucket/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -33,10 +38,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3Bucket/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AWS::S3Bucket`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-aws-s3bucket+v1.0.0).
+* Issues related to `TF::AWS::S3Bucket` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3Bucket/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-aws-s3bucket/package.json
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-aws-s3bucket",
   "description": "Provides a S3 bucket resource.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-aws-s3bucketobject/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucketobject/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-aws-s3bucketobject
+# tf-aws-s3bucketobject
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AWS::S3BucketObject` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 Provides a S3 bucket object resource.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3BucketObject/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3BucketObject/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AWS::S3BucketObject`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-aws-s3bucketobject+v1.0.0).
+* Issues related to `TF::AWS::S3BucketObject` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3BucketObject/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-aws-s3bucketobject/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucketobject/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-aws-s3bucketobject
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AWS::S3BucketObject` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AWS::S3BucketObject` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-aws-s3bucketobject/README.md
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucketobject/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::AWS::S3BucketObject
+# @cdk-cloudformation/tf-aws-s3bucketobject
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AWS::S3BucketObject` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Provides a S3 bucket object resource.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AWS::S3BucketObject \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AWS-S3BucketObject \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/aws/TF-AWS-S3BucketObject/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-aws-s3bucketobject/package.json
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucketobject/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-aws-s3bucketobject",
   "description": "Provides a S3 bucket object resource.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-azuread-application/README.md
+++ b/packages/@cdk-cloudformation/tf-azuread-application/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-azuread-application
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AzureAD::Application` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AzureAD::Application` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-azuread-application/README.md
+++ b/packages/@cdk-cloudformation/tf-azuread-application/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-azuread-application
+# tf-azuread-application
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AzureAD::Application` v1.0.0.
 
@@ -10,6 +10,11 @@
 Manages an Application within Azure Active Directory.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write owned by applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-Application/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -33,10 +38,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-Application/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AzureAD::Application`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-azuread-application+v1.0.0).
+* Issues related to `TF::AzureAD::Application` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-Application/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-azuread-application/README.md
+++ b/packages/@cdk-cloudformation/tf-azuread-application/README.md
@@ -1,11 +1,42 @@
-# AWS CDK CloudFormation Constructs for TF::AzureAD::Application
+# @cdk-cloudformation/tf-azuread-application
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AzureAD::Application` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Manages an Application within Azure Active Directory.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read and write owned by applications` and `Sign in and read user profile` within the `Windows Azure Active Directory` API.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AzureAD::Application \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AzureAD-Application \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-Application/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-azuread-application/package.json
+++ b/packages/@cdk-cloudformation/tf-azuread-application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-azuread-application",
   "description": "Manages an Application within Azure Active Directory.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-azuread-user/README.md
+++ b/packages/@cdk-cloudformation/tf-azuread-user/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-azuread-user
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AzureAD::User` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AzureAD::User` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-azuread-user/README.md
+++ b/packages/@cdk-cloudformation/tf-azuread-user/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-azuread-user
+# tf-azuread-user
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::AzureAD::User` v1.0.0.
 
@@ -10,6 +10,11 @@
 Manages a User within Azure Active Directory.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Directory.ReadWrite.All` within the `Windows Azure Active Directory` API.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-User/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -33,10 +38,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-User/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::AzureAD::User`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-azuread-user+v1.0.0).
+* Issues related to `TF::AzureAD::User` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-User/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-azuread-user/README.md
+++ b/packages/@cdk-cloudformation/tf-azuread-user/README.md
@@ -1,11 +1,42 @@
-# AWS CDK CloudFormation Constructs for TF::AzureAD::User
+# @cdk-cloudformation/tf-azuread-user
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::AzureAD::User` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Manages a User within Azure Active Directory.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Directory.ReadWrite.All` within the `Windows Azure Active Directory` API.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::AzureAD::User \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-AzureAD-User \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/azuread/TF-AzureAD-User/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-azuread-user/package.json
+++ b/packages/@cdk-cloudformation/tf-azuread-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-azuread-user",
   "description": "Manages a User within Azure Active Directory.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-cloudflare-record/README.md
+++ b/packages/@cdk-cloudformation/tf-cloudflare-record/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-cloudflare-record
+# tf-cloudflare-record
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Cloudflare::Record` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 Provides a Cloudflare record resource.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/cloudflare/TF-Cloudflare-Record/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/cloudflare/TF-Cloudflare-Record/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::Cloudflare::Record`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-cloudflare-record+v1.0.0).
+* Issues related to `TF::Cloudflare::Record` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/cloudflare/TF-Cloudflare-Record/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-cloudflare-record/README.md
+++ b/packages/@cdk-cloudformation/tf-cloudflare-record/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::Cloudflare::Record
+# @cdk-cloudformation/tf-cloudflare-record
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Cloudflare::Record` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Provides a Cloudflare record resource.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::Cloudflare::Record \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-Cloudflare-Record \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/cloudflare/TF-Cloudflare-Record/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-cloudflare-record/README.md
+++ b/packages/@cdk-cloudformation/tf-cloudflare-record/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-cloudflare-record
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Cloudflare::Record` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Cloudflare::Record` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-cloudflare-record/package.json
+++ b/packages/@cdk-cloudformation/tf-cloudflare-record/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-cloudflare-record",
   "description": "Provides a Cloudflare record resource.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-digitalocean-droplet/README.md
+++ b/packages/@cdk-cloudformation/tf-digitalocean-droplet/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-digitalocean-droplet
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::DigitalOcean::Droplet` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::DigitalOcean::Droplet` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-digitalocean-droplet/README.md
+++ b/packages/@cdk-cloudformation/tf-digitalocean-droplet/README.md
@@ -1,11 +1,42 @@
-# AWS CDK CloudFormation Constructs for TF::DigitalOcean::Droplet
+# @cdk-cloudformation/tf-digitalocean-droplet
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::DigitalOcean::Droplet` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Provides a DigitalOcean Droplet resource. This can be used to create,
 modify, and delete Droplets. Droplets also support
 [provisioning](https://www.terraform.io/docs/language/resources/provisioners/syntax.html).
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::DigitalOcean::Droplet \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-DigitalOcean-Droplet \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/digitalocean/TF-DigitalOcean-Droplet/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-digitalocean-droplet/README.md
+++ b/packages/@cdk-cloudformation/tf-digitalocean-droplet/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-digitalocean-droplet
+# tf-digitalocean-droplet
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::DigitalOcean::Droplet` v1.0.0.
 
@@ -10,6 +10,11 @@
 Provides a DigitalOcean Droplet resource. This can be used to create,
 modify, and delete Droplets. Droplets also support
 [provisioning](https://www.terraform.io/docs/language/resources/provisioners/syntax.html).
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/digitalocean/TF-DigitalOcean-Droplet/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -33,10 +38,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/digitalocean/TF-DigitalOcean-Droplet/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::DigitalOcean::Droplet`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-digitalocean-droplet+v1.0.0).
+* Issues related to `TF::DigitalOcean::Droplet` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/digitalocean/TF-DigitalOcean-Droplet/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-digitalocean-droplet/package.json
+++ b/packages/@cdk-cloudformation/tf-digitalocean-droplet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-digitalocean-droplet",
   "description": "Provides a DigitalOcean Droplet resource. This can be used to create,",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-github-repository/README.md
+++ b/packages/@cdk-cloudformation/tf-github-repository/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-github-repository
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::GitHub::Repository` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::GitHub::Repository` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-github-repository/README.md
+++ b/packages/@cdk-cloudformation/tf-github-repository/README.md
@@ -1,10 +1,41 @@
-# AWS CDK CloudFormation Constructs for TF::GitHub::Repository
+# @cdk-cloudformation/tf-github-repository
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::GitHub::Repository` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 This resource allows you to create and manage repositories within your
 GitHub organization or personal account.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::GitHub::Repository \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-GitHub-Repository \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/github/TF-GitHub-Repository/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-github-repository/README.md
+++ b/packages/@cdk-cloudformation/tf-github-repository/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-github-repository
+# tf-github-repository
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::GitHub::Repository` v1.0.0.
 
@@ -9,6 +9,11 @@
 
 This resource allows you to create and manage repositories within your
 GitHub organization or personal account.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/github/TF-GitHub-Repository/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -32,10 +37,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/github/TF-GitHub-Repository/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::GitHub::Repository`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-github-repository+v1.0.0).
+* Issues related to `TF::GitHub::Repository` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/github/TF-GitHub-Repository/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-github-repository/package.json
+++ b/packages/@cdk-cloudformation/tf-github-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-github-repository",
   "description": "This resource allows you to create and manage repositories within your",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-google-storagebucket/README.md
+++ b/packages/@cdk-cloudformation/tf-google-storagebucket/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-google-storagebucket
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Google::StorageBucket` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Google::StorageBucket` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-google-storagebucket/README.md
+++ b/packages/@cdk-cloudformation/tf-google-storagebucket/README.md
@@ -1,4 +1,10 @@
-# AWS CDK CloudFormation Constructs for TF::Google::StorageBucket
+# @cdk-cloudformation/tf-google-storagebucket
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Google::StorageBucket` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Creates a new bucket in Google cloud storage service (GCS).
 Once a bucket has been created, its location can't be changed.
@@ -10,9 +16,34 @@ and
 
 **Note**: If the project id is not set on the resource or in the provider block it will be dynamically
 determined which will require enabling the compute api.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::Google::StorageBucket \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-Google-StorageBucket \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/google/TF-Google-StorageBucket/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-google-storagebucket/README.md
+++ b/packages/@cdk-cloudformation/tf-google-storagebucket/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-google-storagebucket
+# tf-google-storagebucket
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Google::StorageBucket` v1.0.0.
 
@@ -17,6 +17,11 @@ and
 
 **Note**: If the project id is not set on the resource or in the provider block it will be dynamically
 determined which will require enabling the compute api.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/google/TF-Google-StorageBucket/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -40,10 +45,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/google/TF-Google-StorageBucket/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::Google::StorageBucket`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-google-storagebucket+v1.0.0).
+* Issues related to `TF::Google::StorageBucket` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/google/TF-Google-StorageBucket/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-google-storagebucket/package.json
+++ b/packages/@cdk-cloudformation/tf-google-storagebucket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-google-storagebucket",
   "description": "Creates a new bucket in Google cloud storage service (GCS).",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-pagerduty-service/README.md
+++ b/packages/@cdk-cloudformation/tf-pagerduty-service/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-pagerduty-service
+# tf-pagerduty-service
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::PagerDuty::Service` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 A [service](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/get_services) represents something you monitor (like a web service, email service, or database service). It is a container for related incidents that associates them with escalation policies.
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/pagerduty/TF-PagerDuty-Service/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/pagerduty/TF-PagerDuty-Service/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::PagerDuty::Service`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-pagerduty-service+v1.0.0).
+* Issues related to `TF::PagerDuty::Service` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/pagerduty/TF-PagerDuty-Service/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-pagerduty-service/README.md
+++ b/packages/@cdk-cloudformation/tf-pagerduty-service/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::PagerDuty::Service
+# @cdk-cloudformation/tf-pagerduty-service
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::PagerDuty::Service` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 A [service](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/get_services) represents something you monitor (like a web service, email service, or database service). It is a container for related incidents that associates them with escalation policies.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::PagerDuty::Service \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-PagerDuty-Service \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/pagerduty/TF-PagerDuty-Service/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-pagerduty-service/README.md
+++ b/packages/@cdk-cloudformation/tf-pagerduty-service/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-pagerduty-service
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::PagerDuty::Service` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::PagerDuty::Service` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-pagerduty-service/package.json
+++ b/packages/@cdk-cloudformation/tf-pagerduty-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-pagerduty-service",
   "description": "A [service](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/get_services) represents something you monitor (like a web service, email service, or database service). It is a container for related incidents that associates them with escalation policies.",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-random-string/README.md
+++ b/packages/@cdk-cloudformation/tf-random-string/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-random-string
+# tf-random-string
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Random::String` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 CloudFormation equivalent of random_string
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-String/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-String/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::Random::String`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-random-string+v1.0.0).
+* Issues related to `TF::Random::String` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-String/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-random-string/README.md
+++ b/packages/@cdk-cloudformation/tf-random-string/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-random-string
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Random::String` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Random::String` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-random-string/README.md
+++ b/packages/@cdk-cloudformation/tf-random-string/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::Random::String
+# @cdk-cloudformation/tf-random-string
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Random::String` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 CloudFormation equivalent of random_string
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::Random::String \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-Random-String \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-String/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-random-string/package.json
+++ b/packages/@cdk-cloudformation/tf-random-string/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-random-string",
   "description": "CloudFormation equivalent of random_string",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-random-uuid/README.md
+++ b/packages/@cdk-cloudformation/tf-random-uuid/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/tf-random-uuid
+# tf-random-uuid
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Random::Uuid` v1.0.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 CloudFormation equivalent of random_uuid
+
+## References
+
+* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-Uuid/docs/README.md)
+* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-Uuid/docs/README.md)
-* [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TF::Random::Uuid`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftf-random-uuid+v1.0.0).
+* Issues related to `TF::Random::Uuid` should be reported to the [publisher](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-Uuid/docs/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/tf-random-uuid/README.md
+++ b/packages/@cdk-cloudformation/tf-random-uuid/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TF::Random::Uuid
+# @cdk-cloudformation/tf-random-uuid
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Random::Uuid` v1.0.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 CloudFormation equivalent of random_uuid
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TF::Random::Uuid \
+  --publisher-id e1238fdd31aee1839e14fb3fb2dac9db154dae29 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/e1238fdd31aee1839e14fb3fb2dac9db154dae29/TF-Random-Uuid \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/iann0036/cfn-tf-custom-types/blob/docs/resources/random/TF-Random-Uuid/docs/README.md)
 * [Source](https://github.com/iann0036/cfn-tf-custom-types.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/tf-random-uuid/README.md
+++ b/packages/@cdk-cloudformation/tf-random-uuid/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/tf-random-uuid
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TF::Random::Uuid` v1.0.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TF::Random::Uuid` v1.0.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/tf-random-uuid/package.json
+++ b/packages/@cdk-cloudformation/tf-random-uuid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-random-uuid",
   "description": "CloudFormation equivalent of random_uuid",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/README.md
+++ b/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/README.md
@@ -1,4 +1,4 @@
-# @cdk-cloudformation/trendmicro-cloudonecontainer-helm
+# trendmicro-cloudonecontainer-helm
 
 > AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TrendMicro::CloudOneContainer::Helm` v1.2.0.
 
@@ -8,6 +8,11 @@
 ## Description
 
 Deploys Trend Micro Cloud One Container Security into EKS clusters using helm.
+
+## References
+
+* [Documentation](https://github.com/trendmicro/cloudone-container-security-helm/blob/master/README.md)
+* [Source](https://github.com/aws-quickstart/quickstart-trend-micro-cloudone-helm-resource-provider.git)
 
 ## Usage
 
@@ -31,10 +36,14 @@ aws cloudformation activate-type \
 
 You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
 
-## References
+## Feedback
 
-* [Documentation](https://github.com/trendmicro/cloudone-container-security-helm/blob/master/README.md)
-* [Source](https://github.com/aws-quickstart/quickstart-trend-micro-cloudone-helm-resource-provider.git)
+This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for `TrendMicro::CloudOneContainer::Helm`.
+
+* Issues related to this generated library should be [reported here](https://github.com/cdklabs/cdk-cloudformation/issues/new?title=Issue+with+%40cdk-cloudformation%2Ftrendmicro-cloudonecontainer-helm+v1.2.0).
+* Issues related to `TrendMicro::CloudOneContainer::Helm` should be reported to the [publisher](https://github.com/trendmicro/cloudone-container-security-helm/blob/master/README.md).
+
+[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation
 
 ## License
 

--- a/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/README.md
+++ b/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/README.md
@@ -1,9 +1,40 @@
-# AWS CDK CloudFormation Constructs for TrendMicro::CloudOneContainer::Helm
+# @cdk-cloudformation/trendmicro-cloudonecontainer-helm
+
+> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TrendMicro::CloudOneContainer::Helm` v1.2.0.
+
+[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
+
+## Description
 
 Deploys Trend Micro Cloud One Container Security into EKS clusters using helm.
+
+## Usage
+
+In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:
+
+```sh
+aws cloudformation activate-type \
+  --type-name TrendMicro::CloudOneContainer::Helm \
+  --publisher-id 408988dff9e863704bcc72e7e13f8d645cee8311 \
+  --type RESOURCE \
+  --execution-role-arn ROLE-ARN
+```
+
+Alternatively:
+
+```sh
+aws cloudformation activate-type \
+  --public-type-arn arn:aws:cloudformation:us-east-1::type/resource/408988dff9e863704bcc72e7e13f8d645cee8311/TrendMicro-CloudOneContainer-Helm \
+  --execution-role-arn ROLE-ARN
+```
+
+You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).
+
 ## References
+
 * [Documentation](https://github.com/trendmicro/cloudone-container-security-helm/blob/master/README.md)
 * [Source](https://github.com/aws-quickstart/quickstart-trend-micro-cloudone-helm-resource-provider.git)
+
 ## License
 
 Distributed under the Apache-2.0 License.

--- a/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/README.md
+++ b/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/README.md
@@ -1,7 +1,8 @@
 # @cdk-cloudformation/trendmicro-cloudonecontainer-helm
 
-> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type `TrendMicro::CloudOneContainer::Helm` v1.2.0.
+> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type `TrendMicro::CloudOneContainer::Helm` v1.2.0.
 
+[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
 ## Description

--- a/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/package.json
+++ b/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/trendmicro-cloudonecontainer-helm",
   "description": "Deploys Trend Micro Cloud One Container Security into EKS clusters using helm.",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/projenrc/readme.ts
+++ b/projenrc/readme.ts
@@ -1,9 +1,11 @@
+import { URL } from 'url';
 import { CloudFormation } from 'aws-sdk';
 import { Component, Project, TextFile } from 'projen';
 
 export interface ReadmeOptions {
   readonly npmName: string;
   readonly typeName: string;
+  readonly kebabName: string;
   readonly type: CloudFormation.DescribeTypeOutput;
 }
 
@@ -16,7 +18,7 @@ export class Readme extends Component {
 
     const readme = new Array<string>();
 
-    readme.push(`# ${options.npmName}`);
+    readme.push(`# ${options.kebabName}`);
     readme.push('');
 
     const version = options.type.LatestPublicVersion ? ` v${options.type.LatestPublicVersion}` : '';
@@ -31,6 +33,18 @@ export class Readme extends Component {
       readme.push('## Description');
       readme.push('');
       readme.push(description);
+    }
+
+    if (options.type.DocumentationUrl || options.type.SourceUrl) {
+      readme.push('');
+      readme.push('## References');
+      readme.push('');
+      if (options.type.DocumentationUrl) {
+        readme.push(`* [Documentation](${options.type.DocumentationUrl})`);
+      }
+      if (options.type.SourceUrl) {
+        readme.push(`* [Source](${options.type.SourceUrl})`);
+      }
     }
 
     readme.push('');
@@ -57,18 +71,22 @@ export class Readme extends Component {
 
     readme.push('You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).');
 
-    if (options.type.DocumentationUrl || options.type.SourceUrl) {
-      readme.push('');
-      readme.push('## References');
-      readme.push('');
-      if (options.type.DocumentationUrl) {
-        readme.push(`* [Documentation](${options.type.DocumentationUrl})`);
-      }
-      if (options.type.SourceUrl) {
-        readme.push(`* [Source](${options.type.SourceUrl})`);
-      }
-    }
 
+    readme.push('');
+    readme.push('## Feedback');
+    readme.push('');
+    readme.push(`This library is auto-generated and published to all supported programming languages by the [cdklabs/cdk-cloudformation] project based on the API schema published for \`${typeName}\`.`);
+    readme.push('');
+
+    const newIssueUrl = new URL('https://github.com/cdklabs/cdk-cloudformation/issues/new');
+    newIssueUrl.searchParams.append('title', `Issue with ${options.npmName}${version}`);
+
+    readme.push(`* Issues related to this generated library should be [reported here](${newIssueUrl.toString()}).`);
+
+    const publisherUrl = options.type.DocumentationUrl ?? options.type.SourceUrl;
+    readme.push(`* Issues related to \`${typeName}\` should be reported to the [publisher](${publisherUrl}).`);
+    readme.push('');
+    readme.push('[cdklabs/cdk-cloudformation]: https://github.com/cdklabs/cdk-cloudformation');
 
     readme.push('');
     readme.push('## License');

--- a/projenrc/readme.ts
+++ b/projenrc/readme.ts
@@ -1,0 +1,80 @@
+import { CloudFormation } from 'aws-sdk';
+import { Component, Project, TextFile } from 'projen';
+
+export interface ReadmeOptions {
+  readonly npmName: string;
+  readonly typeName: string;
+  readonly type: CloudFormation.DescribeTypeOutput;
+}
+
+export class Readme extends Component {
+  constructor(project: Project, options: ReadmeOptions) {
+    super(project);
+    const typeName = options.typeName;;
+
+    const description = options.type.Description ?? `Constructs for ${typeName}`;
+
+    const readme = new Array<string>();
+
+    readme.push(`# ${options.npmName}`);
+    readme.push('');
+
+    const version = options.type.LatestPublicVersion ? ` v${options.type.LatestPublicVersion}` : '';
+
+    readme.push(`> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type \`${typeName}\`${version}.`);
+    readme.push('');
+    readme.push('[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html');
+    readme.push('');
+
+    if (options.type.Description) {
+      readme.push('## Description');
+      readme.push('');
+      readme.push(description);
+    }
+
+    readme.push('');
+    readme.push('## Usage');
+    readme.push('');
+    readme.push('In order to use this library, you will need to activate this AWS CloudFormation Registry type in your account. You can do this via the AWS Management Console or using the [AWS CLI](https://aws.amazon.com/cli/) using the following command:');
+    readme.push('');
+    readme.push('```sh');
+    readme.push('aws cloudformation activate-type \\');
+    readme.push(`  --type-name ${typeName} \\`);
+    readme.push(`  --publisher-id ${options.type.PublisherId} \\`);
+    readme.push(`  --type ${options.type.Type} \\`);
+    readme.push('  --execution-role-arn ROLE-ARN');
+    readme.push('```');
+    readme.push('');
+    readme.push('Alternatively:');
+    readme.push('');
+    readme.push('```sh');
+    readme.push('aws cloudformation activate-type \\');
+    readme.push(`  --public-type-arn ${options.type.Arn} \\`);
+    readme.push('  --execution-role-arn ROLE-ARN');
+    readme.push('```');
+    readme.push('');
+
+    readme.push('You can find more information about activating this type in the [AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry-public.html).');
+
+    if (options.type.DocumentationUrl || options.type.SourceUrl) {
+      readme.push('');
+      readme.push('## References');
+      readme.push('');
+      if (options.type.DocumentationUrl) {
+        readme.push(`* [Documentation](${options.type.DocumentationUrl})`);
+      }
+      if (options.type.SourceUrl) {
+        readme.push(`* [Source](${options.type.SourceUrl})`);
+      }
+    }
+
+
+    readme.push('');
+    readme.push('## License');
+    readme.push('');
+    readme.push('Distributed under the Apache-2.0 License.');
+    readme.push('');
+
+    new TextFile(project, 'README.md', { lines: readme });
+  }
+}

--- a/projenrc/readme.ts
+++ b/projenrc/readme.ts
@@ -21,8 +21,9 @@ export class Readme extends Component {
 
     const version = options.type.LatestPublicVersion ? ` v${options.type.LatestPublicVersion}` : '';
 
-    readme.push(`> An AWS CDK L1 construct for the [AWS CloudFormation Registry] type \`${typeName}\`${version}.`);
+    readme.push(`> AWS CDK [L1 construct] and data structures for the [AWS CloudFormation Registry] type \`${typeName}\`${version}.`);
     readme.push('');
+    readme.push('[L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html');
     readme.push('[AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html');
     readme.push('');
 

--- a/projenrc/type-package.ts
+++ b/projenrc/type-package.ts
@@ -80,6 +80,7 @@ export class CloudFormationTypeProject extends Component {
       type: options.type,
       typeName: typeName,
       npmName: npmName,
+      kebabName: typeNameKebab,
     });
 
     if (!options.type.LatestPublicVersion) {

--- a/projenrc/type-package.ts
+++ b/projenrc/type-package.ts
@@ -3,10 +3,11 @@ import { dirname, join } from 'path';
 import type { CloudFormation } from 'aws-sdk';
 import * as caseutil from 'case';
 import { CfnResourceGenerator } from 'cdk-import/lib/cfn-resource-generator';
-import { Component, JsonFile, License, Project, TextFile, TypeScriptProject } from 'projen';
+import { Component, JsonFile, License, Project, TypeScriptProject } from 'projen';
 import { TaskWorkflow } from 'projen/lib/github';
 import { JobPermission } from 'projen/lib/github/workflows-model';
 import { Publisher } from 'projen/lib/release';
+import { Readme } from './readme';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const CDK_VERSION = require('@aws-cdk/core/package.json').version;
@@ -73,31 +74,13 @@ export class CloudFormationTypeProject extends Component {
     new License(project, { spdx });
 
     const description = options.type.Description ?? `Constructs for ${typeName}`;
+    const npmName = `${npmScope}/${typeNameKebab}`;
 
-    const readme = [
-      `# AWS CDK CloudFormation Constructs for ${typeName}`,
-      '',
-    ];
-
-    readme.push(description);
-    readme.push();
-
-    if (options.type.DocumentationUrl || options.type.SourceUrl) {
-      readme.push('## References');
-      if (options.type.DocumentationUrl) {
-        readme.push(`* [Documentation](${options.type.DocumentationUrl})`);
-      }
-      if (options.type.SourceUrl) {
-        readme.push(`* [Source](${options.type.SourceUrl})`);
-      }
-      readme.push();
-    }
-
-    readme.push('## License');
-    readme.push('');
-    readme.push('Distributed under the Apache-2.0 License.');
-
-    new TextFile(project, 'README.md', { lines: readme });
+    new Readme(project, {
+      type: options.type,
+      typeName: typeName,
+      npmName: npmName,
+    });
 
     if (!options.type.LatestPublicVersion) {
       console.warn(`${typeName} does not have a LatestPublicVersion`);
@@ -110,7 +93,7 @@ export class CloudFormationTypeProject extends Component {
 
     new JsonFile(project, 'package.json', {
       obj: {
-        name: `${npmScope}/${typeNameKebab}`,
+        name: npmName,
         description: description.split('\n')[0], // only first line
         version: version,
         author: {
@@ -256,7 +239,9 @@ export class CloudFormationTypeProject extends Component {
 
     releaseWorkflow.addJobs(publisher.render());
 
+    // used in the main README to list the release status of all packages
     this.statusBadge = `[![${typeNameKebab}](https://github.com/cdklabs/cdk-cloudformation/actions/workflows/${releaseWorkflow.name}.yml/badge.svg)](https://github.com/cdklabs/cdk-cloudformation/actions/workflows/${releaseWorkflow.name}.yml)`;
+
 
     this.subproject = project;
   }


### PR DESCRIPTION
Improve READMEs for generated modules.

* Add verbiage that this is an AWS CDK L1 construct
* Separate user-provided description into its own section
* Add “Usage” section with instructions on how to activate the type
* Lint markdown


Bump version to `alpha.2`

Fixes #4 

