### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release-alexa-ask-skill.yml
+++ b/.github/workflows/release-alexa-ask-skill.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-aqua-enterprise-enforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-enforcer.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-aqua-enterprise-scanner.yml
+++ b/.github/workflows/release-aqua-enterprise-scanner.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-aqua-enterprise-server.yml
+++ b/.github/workflows/release-aqua-enterprise-server.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-atlassian-opsgenie-integration.yml
+++ b/.github/workflows/release-atlassian-opsgenie-integration.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-atlassian-opsgenie-team.yml
+++ b/.github/workflows/release-atlassian-opsgenie-team.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-atlassian-opsgenie-user.yml
+++ b/.github/workflows/release-atlassian-opsgenie-user.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
+++ b/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
+++ b/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-eks-cluster.yml
+++ b/.github/workflows/release-awsqs-eks-cluster.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
+++ b/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-kubernetes-get.yml
+++ b/.github/workflows/release-awsqs-kubernetes-get.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-kubernetes-helm.yml
+++ b/.github/workflows/release-awsqs-kubernetes-helm.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-kubernetes-resource.yml
+++ b/.github/workflows/release-awsqs-kubernetes-resource.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
+++ b/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-datadog-dashboards-dashboard.yml
+++ b/.github/workflows/release-datadog-dashboards-dashboard.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-datadog-integrations-aws.yml
+++ b/.github/workflows/release-datadog-integrations-aws.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-datadog-monitors-downtime.yml
+++ b/.github/workflows/release-datadog-monitors-downtime.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-datadog-monitors-monitor.yml
+++ b/.github/workflows/release-datadog-monitors-monitor.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-datadog-slos-slo.yml
+++ b/.github/workflows/release-datadog-slos-slo.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
+++ b/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-generic-database-schema.yml
+++ b/.github/workflows/release-generic-database-schema.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-generic-transcribe-vocabulary.yml
+++ b/.github/workflows/release-generic-transcribe-vocabulary.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-gremlin-agent-helm.yml
+++ b/.github/workflows/release-gremlin-agent-helm.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-artifactory-core-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-core-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-linux-bastion-module.yml
+++ b/.github/workflows/release-jfrog-linux-bastion-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-vpc-multiaz-module.yml
+++ b/.github/workflows/release-jfrog-vpc-multiaz-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-jfrog-xray-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-xray-ec2instance-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
+++ b/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-logzio-awscostandusage-cur-module.yml
+++ b/.github/workflows/release-logzio-awscostandusage-cur-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
+++ b/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
+++ b/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-logzio-myservice-myname-module.yml
+++ b/.github/workflows/release-logzio-myservice-myname-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-mongodb-atlas-cluster.yml
+++ b/.github/workflows/release-mongodb-atlas-cluster.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-mongodb-atlas-databaseuser.yml
+++ b/.github/workflows/release-mongodb-atlas-databaseuser.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-mongodb-atlas-networkpeering.yml
+++ b/.github/workflows/release-mongodb-atlas-networkpeering.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-mongodb-atlas-project.yml
+++ b/.github/workflows/release-mongodb-atlas-project.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
+++ b/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-registry-test-resource1-module.yml
+++ b/.github/workflows/release-registry-test-resource1-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-snyk-container-helm.yml
+++ b/.github/workflows/release-snyk-container-helm.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-splunk-enterprise-quickstart-module.yml
+++ b/.github/workflows/release-splunk-enterprise-quickstart-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-spot-elastigroup-group.yml
+++ b/.github/workflows/release-spot-elastigroup-group.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-stackery-open-bastion-module.yml
+++ b/.github/workflows/release-stackery-open-bastion-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-stocks-orders-marketorder.yml
+++ b/.github/workflows/release-stocks-orders-marketorder.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
+++ b/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-sysdig-helm-agent.yml
+++ b/.github/workflows/release-sysdig-helm-agent.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-ad-computer.yml
+++ b/.github/workflows/release-tf-ad-computer.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-ad-user.yml
+++ b/.github/workflows/release-tf-ad-user.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-aws-keypair.yml
+++ b/.github/workflows/release-tf-aws-keypair.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-aws-s3bucket.yml
+++ b/.github/workflows/release-tf-aws-s3bucket.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-aws-s3bucketobject.yml
+++ b/.github/workflows/release-tf-aws-s3bucketobject.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-azuread-application.yml
+++ b/.github/workflows/release-tf-azuread-application.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-azuread-user.yml
+++ b/.github/workflows/release-tf-azuread-user.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-cloudflare-record.yml
+++ b/.github/workflows/release-tf-cloudflare-record.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-digitalocean-droplet.yml
+++ b/.github/workflows/release-tf-digitalocean-droplet.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-github-repository.yml
+++ b/.github/workflows/release-tf-github-repository.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-google-storagebucket.yml
+++ b/.github/workflows/release-tf-google-storagebucket.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-pagerduty-service.yml
+++ b/.github/workflows/release-tf-pagerduty-service.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-random-string.yml
+++ b/.github/workflows/release-tf-random-string.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-tf-random-uuid.yml
+++ b/.github/workflows/release-tf-random-uuid.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
+++ b/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: {}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v2.1.1
         if: always()
         with:
-          name: dist
+          name: build-artifact
           path: dist
     container:
       image: jsii/superchain:1-buster-slim-node14


### PR DESCRIPTION
projen was on a pretty old version and there have been a couple of
breaking changes in the versions since. Upgraded projen to the newest
version and made the necessary API changes.
