### PR TITLE
fix: update token for auto upgrade workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,4 +18,4 @@ jobs:
     steps:
       - uses: hmarr/auto-approve-action@v2.2.1
         with:
-          github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -10,7 +10,7 @@ const project = new typescript.TypeScriptProject({
   sampleCode: false,
   autoApproveOptions: {
     allowedUsernames: ['cdklabs-automation'],
-    secret: 'PROJEN_GITHUB_TOKEN',
+    secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,
 });


### PR DESCRIPTION
We are currently seeing errors during our `upgrade dependencies auto upgrade workflow` like,

```
Error: Unprocessable Entity: "Can not approve your own pull request". This typically happens when you try to approve the pull request with the same user account that created the pull request. Try using the built-in `${{ secrets.GITHUB_TOKEN }}` token, or if you're using a personal access token, use one that belongs to a dedicated bot account.
```

This PR is updating the secret being currently used for auto upgrade workflow.

Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>