### PR TITLE
fix: prefix deprecations are not marked as deprecated

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -28,3 +28,8 @@ jobs:
           branch: automation/update-registry
           committer: GitHub Automation <noreply@github.com>
           labels: auto-approve
+      - uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,7 +51,7 @@ const projects = generatePackages(project, {
   ],
   dir: packagesDir,
   scope: scope,
-  prerelease: 'alpha.6',
+  prerelease: 'alpha.7',
 });
 
 updateReadme(project, projects);

--- a/packages/@cdk-cloudformation/alexa-ask-skill/package.json
+++ b/packages/@cdk-cloudformation/alexa-ask-skill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/alexa-ask-skill",
   "description": "Constructs for Alexa::ASK::Skill",
-  "version": "0.0.0-alpha.6",
+  "version": "0.0.0-alpha.7",
   "deprecated": true,
   "author": {
     "name": "Amazon Web Services",

--- a/packages/@cdk-cloudformation/aqua-enterprise-enforcer/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-enforcer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-enforcer",
   "description": "A resource provider for Aqua Enterprise Enforcer.",
-  "version": "1.6.0-alpha.6",
+  "version": "1.6.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-kubeenforcer",
   "description": "A resource provider for Aqua Enterprise KubeEnforcer.",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-scanner/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-scanner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-scanner",
   "description": "A resource provider for Aqua Enterprise Scanner.",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/aqua-enterprise-server/package.json
+++ b/packages/@cdk-cloudformation/aqua-enterprise-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/aqua-enterprise-server",
   "description": "A resource provider for Aqua Enterprise Server.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-integration/package.json
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-integration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/atlassian-opsgenie-integration",
   "description": "Opsgenie Integration Resource definition",
-  "version": "1.0.1-alpha.6",
+  "version": "1.0.1-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-team/package.json
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/atlassian-opsgenie-team",
   "description": "Opsgenie Team resource schema",
-  "version": "1.0.1-alpha.6",
+  "version": "1.0.1-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/atlassian-opsgenie-user/package.json
+++ b/packages/@cdk-cloudformation/atlassian-opsgenie-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/atlassian-opsgenie-user",
   "description": "Opsgenie User",
-  "version": "1.0.1-alpha.6",
+  "version": "1.0.1-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awscommunity-account-alternatecontact/package.json
+++ b/packages/@cdk-cloudformation/awscommunity-account-alternatecontact/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awscommunity-account-alternatecontact",
   "description": "An alternate contact attached to an Amazon Web Services account.",
-  "version": "1.3.0-alpha.6",
+  "version": "1.3.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awscommunity-s3-deletebucketcontents/package.json
+++ b/packages/@cdk-cloudformation/awscommunity-s3-deletebucketcontents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awscommunity-s3-deletebucketcontents",
   "description": "An experimental extension that deletes all contents of the referenced bucket when the stack is deleted. Use with caution!",
-  "version": "1.8.0-alpha.6",
+  "version": "1.8.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module",
   "description": "Schema for Module Fragment of type AWSQS::CheckPoint::CloudGuardQS::MODULE",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module",
   "description": "Schema for Module Fragment of type AWSQS::EC2::LinuxBastionQS::MODULE",
-  "version": "1.4.0-alpha.6",
+  "version": "1.4.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-eks-cluster/package.json
+++ b/packages/@cdk-cloudformation/awsqs-eks-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-eks-cluster",
   "description": "A resource that creates Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
-  "version": "1.12.0-alpha.6",
+  "version": "1.12.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module",
   "description": "Schema for Module Fragment of type AWSQS::Iridium::CloudConnectQS::MODULE",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-get/package.json
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-get/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-kubernetes-get",
   "description": "Fetches data from a kubernetes cluster using jsonpath expressions.",
-  "version": "1.13.0-alpha.6",
+  "version": "1.13.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-helm/package.json
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-kubernetes-helm",
   "description": "A resource provider for managing helm. Version: 1.2.1",
-  "version": "1.16.0-alpha.6",
+  "version": "1.16.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-kubernetes-resource/package.json
+++ b/packages/@cdk-cloudformation/awsqs-kubernetes-resource/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-kubernetes-resource",
   "description": "Applys a YAML manifest to the specified Kubernetes cluster",
-  "version": "1.15.0-alpha.6",
+  "version": "1.15.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/package.json
+++ b/packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/awsqs-vpc-vpcqs-module",
   "description": "Schema for Module Fragment of type AWSQS::VPC::VPCQS::MODULE",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/bigid-datasource-dynamodb/package.json
+++ b/packages/@cdk-cloudformation/bigid-datasource-dynamodb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/bigid-datasource-dynamodb",
   "description": "Manage a BigID DynamoDB data source.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/bigid-datasource-s3/package.json
+++ b/packages/@cdk-cloudformation/bigid-datasource-s3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/bigid-datasource-s3",
   "description": "Manage a BigID S3 data source",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/cloudflare-dns-record/package.json
+++ b/packages/@cdk-cloudformation/cloudflare-dns-record/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/cloudflare-dns-record",
   "description": "A Cloudflare resource for managing a single DNS record",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer/package.json
+++ b/packages/@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer",
   "description": "A Cloudflare resource for managing load-balancing across pools",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/cloudflare-loadbalancer-monitor/package.json
+++ b/packages/@cdk-cloudformation/cloudflare-loadbalancer-monitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/cloudflare-loadbalancer-monitor",
   "description": "A Monitor policy to configure monitoring of endpoint health",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/cloudflare-loadbalancer-pool/package.json
+++ b/packages/@cdk-cloudformation/cloudflare-loadbalancer-pool/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/cloudflare-loadbalancer-pool",
   "description": "A resource to manage a pool of origin servers",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/confluentcloud-iam-serviceaccount/package.json
+++ b/packages/@cdk-cloudformation/confluentcloud-iam-serviceaccount/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/confluentcloud-iam-serviceaccount",
   "description": "Service Account as defined in Confluent Cloud IAM v2 API.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/databricks-clusters-cluster/package.json
+++ b/packages/@cdk-cloudformation/databricks-clusters-cluster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/databricks-clusters-cluster",
   "description": "Manage a Databricks Cluster",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/databricks-clusters-job/package.json
+++ b/packages/@cdk-cloudformation/databricks-clusters-job/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/databricks-clusters-job",
   "description": "Manage Jobs running on a cluster",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-dashboards-dashboard/package.json
+++ b/packages/@cdk-cloudformation/datadog-dashboards-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-dashboards-dashboard",
   "description": "Datadog Dashboard 2.0.2",
-  "version": "2.0.2-alpha.6",
+  "version": "2.0.2-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-integrations-aws/package.json
+++ b/packages/@cdk-cloudformation/datadog-integrations-aws/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-integrations-aws",
   "description": "Datadog AWS Integration 2.2.1",
-  "version": "2.3.0-alpha.6",
+  "version": "2.3.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-monitors-downtime/package.json
+++ b/packages/@cdk-cloudformation/datadog-monitors-downtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-monitors-downtime",
   "description": "Datadog Monitors Downtime 3.0.0",
-  "version": "3.0.0-alpha.6",
+  "version": "3.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-monitors-monitor/package.json
+++ b/packages/@cdk-cloudformation/datadog-monitors-monitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-monitors-monitor",
   "description": "Datadog Monitor 4.5.0",
-  "version": "4.5.0-alpha.6",
+  "version": "4.5.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/datadog-slos-slo/package.json
+++ b/packages/@cdk-cloudformation/datadog-slos-slo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/datadog-slos-slo",
   "description": "Datadog SLO 1.0.1",
-  "version": "1.0.1-alpha.6",
+  "version": "1.0.1-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/dynatrace-configuration-dashboard/package.json
+++ b/packages/@cdk-cloudformation/dynatrace-configuration-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/dynatrace-configuration-dashboard",
   "description": "Manage a dashboard in Dynatrace.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/dynatrace-environment-servicelevelobjective/package.json
+++ b/packages/@cdk-cloudformation/dynatrace-environment-servicelevelobjective/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/dynatrace-environment-servicelevelobjective",
   "description": "Manage a Service Level Objective in Dynatrace.",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/dynatrace-environment-syntheticlocation/package.json
+++ b/packages/@cdk-cloudformation/dynatrace-environment-syntheticlocation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/dynatrace-environment-syntheticlocation",
   "description": "Manage a synthetic location (V1) in Dynatrace.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/dynatrace-environment-syntheticmonitor/package.json
+++ b/packages/@cdk-cloudformation/dynatrace-environment-syntheticmonitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/dynatrace-environment-syntheticmonitor",
   "description": "Manage a synthetic monitor (V1) in Dynatrace.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fastly-dictionary-dictionary/package.json
+++ b/packages/@cdk-cloudformation/fastly-dictionary-dictionary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fastly-dictionary-dictionary",
   "description": "Manage a Fastly service dictionary.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fastly-dictionary-dictionaryitem/package.json
+++ b/packages/@cdk-cloudformation/fastly-dictionary-dictionaryitem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fastly-dictionary-dictionaryitem",
   "description": "Manage a Fastly service dictionary item.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fastly-services-backend/package.json
+++ b/packages/@cdk-cloudformation/fastly-services-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fastly-services-backend",
   "description": "Manage a Fastly service backend.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fastly-services-domain/package.json
+++ b/packages/@cdk-cloudformation/fastly-services-domain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fastly-services-domain",
   "description": "Manage a Fastly service domain.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fastly-services-healthcheck/package.json
+++ b/packages/@cdk-cloudformation/fastly-services-healthcheck/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fastly-services-healthcheck",
   "description": "Manage a Fastly service health check.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fastly-services-service/package.json
+++ b/packages/@cdk-cloudformation/fastly-services-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fastly-services-service",
   "description": "Manage a Fastly service.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/package.json
+++ b/packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch",
   "description": "This Resource Type will create necessary resources in your AWS account to forward cloudwatch logs to FireEye Helix. Visit FireEye Cloud Integration Portal for more info and to generate a pre-populated CloudFormation Template",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-impactapi-apigateway-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-impactapi-apigateway-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-impactapi-apigateway-module",
   "description": "Schema for Module Fragment of type FreyrAIM::ImpactApi::ApiGateway::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-impactapi-apihandle-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-impactapi-apihandle-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-impactapi-apihandle-module",
   "description": "Schema for Module Fragment of type FreyrAIM::ImpactApi::ApiHandle::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-impactapi-ec2instance-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-impactapi-ec2instance-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-impactapi-ec2instance-module",
   "description": "Schema for Module Fragment of type FreyrAIM::ImpactApi::EC2Instance::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-impactapi-lambdafunction-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-impactapi-lambdafunction-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-impactapi-lambdafunction-module",
   "description": "Schema for Module Fragment of type FreyrAIM::ImpactApi::LambdaFunction::MODULE",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-impactapi-loadbalancer-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-impactapi-loadbalancer-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-impactapi-loadbalancer-module",
   "description": "Schema for Module Fragment of type FreyrAIM::ImpactApi::LoadBalancer::MODULE",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-spider-cloudfront-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-spider-cloudfront-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-spider-cloudfront-module",
   "description": "Schema for Module Fragment of type FreyrAIM::Spider::CloudFront::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-spider-ec2instance-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-spider-ec2instance-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-spider-ec2instance-module",
   "description": "Schema for Module Fragment of type FreyrAIM::Spider::EC2Instance::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-spider-ecs-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-spider-ecs-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-spider-ecs-module",
   "description": "Schema for Module Fragment of type FreyrAIM::Spider::ECS::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-spider-loadbalancer-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-spider-loadbalancer-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-spider-loadbalancer-module",
   "description": "Schema for Module Fragment of type FreyrAIM::Spider::LoadBalancer::MODULE",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-spider-postgresql-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-spider-postgresql-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-spider-postgresql-module",
   "description": "Schema for Module Fragment of type FreyrAIM::Spider::PostgreSQL::MODULE",
-  "version": "1.4.0-alpha.6",
+  "version": "1.4.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/freyraim-spider-s3bucket-module/package.json
+++ b/packages/@cdk-cloudformation/freyraim-spider-s3bucket-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/freyraim-spider-s3bucket-module",
   "description": "Schema for Module Fragment of type FreyrAIM::Spider::S3Bucket::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/generic-database-schema/package.json
+++ b/packages/@cdk-cloudformation/generic-database-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/generic-database-schema",
   "description": "Uses the Aurora Data API to execute SQL and enforce a schema within a database cluster. Currently only supports Aurora Postgres.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/generic-transcribe-vocabulary/package.json
+++ b/packages/@cdk-cloudformation/generic-transcribe-vocabulary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/generic-transcribe-vocabulary",
   "description": "A custom vocabulary that you can use to change the way Amazon Transcribe handles transcription of an audio file.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-git-tag/package.json
+++ b/packages/@cdk-cloudformation/github-git-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-git-tag",
   "description": "Manage a git tag on GitHub",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-organizations-membership/package.json
+++ b/packages/@cdk-cloudformation/github-organizations-membership/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-organizations-membership",
   "description": "Add people to an organization. Will create an invite and user will only become a member once they accept this invite.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-repositories-collaborator/package.json
+++ b/packages/@cdk-cloudformation/github-repositories-collaborator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-repositories-collaborator",
   "description": "The Collaborators resource allows you to add, invite, and remove collaborators from a repository.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-repositories-repository/package.json
+++ b/packages/@cdk-cloudformation/github-repositories-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-repositories-repository",
   "description": "Manage a repository in GitHub.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-repositories-webhook/package.json
+++ b/packages/@cdk-cloudformation/github-repositories-webhook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-repositories-webhook",
   "description": "Repositories can have multiple webhooks installed. Each webhook should have a unique config. Multiple webhooks can share the same config as long as those webhooks do not have any events that overlap.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-teams-membership/package.json
+++ b/packages/@cdk-cloudformation/github-teams-membership/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-teams-membership",
   "description": "Manages people's membership to GitHub teams",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-teams-repositoryaccess/package.json
+++ b/packages/@cdk-cloudformation/github-teams-repositoryaccess/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-teams-repositoryaccess",
   "description": "Manage a team access to a repository in GitHub.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/github-teams-team/package.json
+++ b/packages/@cdk-cloudformation/github-teams-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/github-teams-team",
   "description": "Manage a team in Github",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-code-tag/package.json
+++ b/packages/@cdk-cloudformation/gitlab-code-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-code-tag",
   "description": "Creates a tag against a code ref in GitLab",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-groups-group/package.json
+++ b/packages/@cdk-cloudformation/gitlab-groups-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-groups-group",
   "description": "Creates a group in GitLab",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-groups-groupaccesstogroup/package.json
+++ b/packages/@cdk-cloudformation/gitlab-groups-groupaccesstogroup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-groups-groupaccesstogroup",
   "description": "Adds a group as a member of another GitLab group",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-groups-usermemberofgroup/package.json
+++ b/packages/@cdk-cloudformation/gitlab-groups-usermemberofgroup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-groups-usermemberofgroup",
   "description": "Adds a user as a member of a GitLab group",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-projects-accesstoken/package.json
+++ b/packages/@cdk-cloudformation/gitlab-projects-accesstoken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-projects-accesstoken",
   "description": "Creates a Project Access Token in GitLab",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-projects-groupaccesstoproject/package.json
+++ b/packages/@cdk-cloudformation/gitlab-projects-groupaccesstoproject/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-projects-groupaccesstoproject",
   "description": "Adds a group as a member of a GitLab project",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-projects-project/package.json
+++ b/packages/@cdk-cloudformation/gitlab-projects-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-projects-project",
   "description": "Creates a project in GitLab",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gitlab-projects-usermemberofproject/package.json
+++ b/packages/@cdk-cloudformation/gitlab-projects-usermemberofproject/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gitlab-projects-usermemberofproject",
   "description": "Adds a user as a member of a GitLab project",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/gremlin-agent-helm/package.json
+++ b/packages/@cdk-cloudformation/gremlin-agent-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/gremlin-agent-helm",
   "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-core-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-core-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-core-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::Core::MODULE",
-  "version": "1.12.0-alpha.6",
+  "version": "1.12.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-ec2instance-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::EC2Instance::MODULE",
-  "version": "1.7.0-alpha.6",
+  "version": "1.7.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-existingvpc-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::ExistingVpc::MODULE",
-  "version": "1.12.0-alpha.6",
+  "version": "1.12.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-artifactory-newvpc-module",
   "description": "Schema for Module Fragment of type JFrog::Artifactory::NewVpc::MODULE",
-  "version": "1.9.0-alpha.6",
+  "version": "1.9.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-linux-bastion-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-linux-bastion-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-linux-bastion-module",
   "description": "Schema for Module Fragment of type JFrog::Linux::Bastion::MODULE",
-  "version": "1.5.0-alpha.6",
+  "version": "1.5.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-vpc-multiaz-module",
   "description": "Schema for Module Fragment of type JFrog::Vpc::MultiAz::MODULE",
-  "version": "1.6.0-alpha.6",
+  "version": "1.6.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/package.json
+++ b/packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/jfrog-xray-ec2instance-module",
   "description": "Schema for Module Fragment of type JFrog::Xray::EC2Instance::MODULE",
-  "version": "1.6.0-alpha.6",
+  "version": "1.6.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/karte-eventbridge-documentdb-module/package.json
+++ b/packages/@cdk-cloudformation/karte-eventbridge-documentdb-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/karte-eventbridge-documentdb-module",
   "description": "Schema for Module Fragment of type KARTE::EventBridge::DocumentDB::MODULE",
-  "version": "1.0.2-alpha.6",
+  "version": "1.0.2-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module",
   "description": "Schema for Module Fragment of type logzio::autoDeploymentLogzio::CloudWatch::MODULE",
-  "version": "2.2.0-alpha.6",
+  "version": "2.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-awscostandusage-cur-module",
   "description": "Schema for Module Fragment of type Logzio::awsCostAndUsage::cur::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-awssecurityhub-collector-module",
   "description": "Schema for Module Fragment of type logzio::awsSecurityHub::collector::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module",
   "description": "Schema for Module Fragment of type Logzio::KinesisShipper::KinesisShipper::MODULE",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/logzio-myservice-myname-module/package.json
+++ b/packages/@cdk-cloudformation/logzio-myservice-myname-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/logzio-myservice-myname-module",
   "description": "Schema for Module Fragment of type Logzio::MyService::MyName::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-cluster/README.md
@@ -5,6 +5,13 @@
 [L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
+---
+
+![Deprecated](https://img.shields.io/badge/deprecated-critical.svg?style=for-the-badge)
+
+> This package is deprecated. Please use the respective `@mongodbatlas-awscdk/*` scoped package instead
+
+---
 ## Description
 
 The cluster resource provides access to your cluster configurations. The resource lets you create, edit and delete clusters. The resource requires your Project ID.

--- a/packages/@cdk-cloudformation/mongodb-atlas-cluster/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-cluster/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-cluster",
   "description": "The cluster resource provides access to your cluster configurations. The resource lets you create, edit and delete clusters. The resource requires your Project ID.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
+  "deprecated": true,
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/README.md
@@ -5,6 +5,13 @@
 [L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
+---
+
+![Deprecated](https://img.shields.io/badge/deprecated-critical.svg?style=for-the-badge)
+
+> This package is deprecated. Please use the respective `@mongodbatlas-awscdk/*` scoped package instead
+
+---
 ## Description
 
 The databaseUsers resource lets you retrieve, create and modify the MongoDB users in your cluster. Each user has a set of roles that provide access to the project?s databases. A user?s roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.

--- a/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-databaseuser/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-databaseuser",
   "description": "The databaseUsers resource lets you retrieve, create and modify the MongoDB users in your cluster. Each user has a set of roles that provide access to the project?s databases. A user?s roles apply to all the clusters in the project: if two clusters have a products database and a user has a role granting read access on the products database, the user has that access on both clusters.",
-  "version": "1.3.0-alpha.6",
+  "version": "1.3.0-alpha.7",
+  "deprecated": true,
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/README.md
@@ -5,6 +5,13 @@
 [L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
+---
+
+![Deprecated](https://img.shields.io/badge/deprecated-critical.svg?style=for-the-badge)
+
+> This package is deprecated. Please use the respective `@mongodbatlas-awscdk/*` scoped package instead
+
+---
 ## Description
 
 This resource allows to create, read, update and delete a network peering

--- a/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-networkpeering/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-networkpeering",
   "description": "This resource allows to create, read, update and delete a network peering",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
+  "deprecated": true,
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-project/README.md
@@ -5,6 +5,13 @@
 [L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
+---
+
+![Deprecated](https://img.shields.io/badge/deprecated-critical.svg?style=for-the-badge)
+
+> This package is deprecated. Please use the respective `@mongodbatlas-awscdk/*` scoped package instead
+
+---
 ## Description
 
 Retrieves or creates projects in any given Atlas organization.

--- a/packages/@cdk-cloudformation/mongodb-atlas-project/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-project/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-project",
   "description": "Retrieves or creates projects in any given Atlas organization.",
-  "version": "1.6.0-alpha.6",
+  "version": "1.6.0-alpha.7",
+  "deprecated": true,
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
+++ b/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/README.md
@@ -5,6 +5,13 @@
 [L1 construct]: https://docs.aws.amazon.com/cdk/latest/guide/constructs.html
 [AWS CloudFormation Registry]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html
 
+---
+
+![Deprecated](https://img.shields.io/badge/deprecated-critical.svg?style=for-the-badge)
+
+> This package is deprecated. Please use the respective `@mongodbatlas-awscdk/*` scoped package instead
+
+---
 ## Description
 
 An example resource schema demonstrating some basic constructs and validation rules.

--- a/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/package.json
+++ b/packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@cdk-cloudformation/mongodb-atlas-projectipaccesslist",
   "description": "An example resource schema demonstrating some basic constructs and validation rules.",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
+  "deprecated": true,
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/newrelic-cloudformation-dashboards/package.json
+++ b/packages/@cdk-cloudformation/newrelic-cloudformation-dashboards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/newrelic-cloudformation-dashboards",
   "description": "CRUDL operations for New Relic Dashboards via the NerdGraph API",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/newrelic-cloudformation-tagging/package.json
+++ b/packages/@cdk-cloudformation/newrelic-cloudformation-tagging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/newrelic-cloudformation-tagging",
   "description": "CRUD operations for New Relic Tags via the NerdGraph API",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/newrelic-cloudformation-workloads/package.json
+++ b/packages/@cdk-cloudformation/newrelic-cloudformation-workloads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/newrelic-cloudformation-workloads",
   "description": "CRUD operations for New Relic Workloads via the NerdGraph API",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/newrelic-observability-dashboards/package.json
+++ b/packages/@cdk-cloudformation/newrelic-observability-dashboards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/newrelic-observability-dashboards",
   "description": "CRUD operations for New Relic Dashboards via the NerdGraph API",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/newrelic-observability-workloads/package.json
+++ b/packages/@cdk-cloudformation/newrelic-observability-workloads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/newrelic-observability-workloads",
   "description": "CRUD operations for New Relic Workloads via the NerdGraph API",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/okta-application-application/package.json
+++ b/packages/@cdk-cloudformation/okta-application-application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/okta-application-application",
   "description": "Manage an Application in Okta.",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/okta-group-group/package.json
+++ b/packages/@cdk-cloudformation/okta-group-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/okta-group-group",
   "description": "Manages an Okta Group",
-  "version": "1.7.0-alpha.6",
+  "version": "1.7.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/okta-group-groupapplicationassociation/package.json
+++ b/packages/@cdk-cloudformation/okta-group-groupapplicationassociation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/okta-group-groupapplicationassociation",
   "description": "Manage Groups assigned to an Application",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/okta-group-membership/package.json
+++ b/packages/@cdk-cloudformation/okta-group-membership/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/okta-group-membership",
   "description": "Adds Okta users to groups",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/okta-policy-policy/package.json
+++ b/packages/@cdk-cloudformation/okta-policy-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/okta-policy-policy",
   "description": "Manages an Okta Policy",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/org-test-sample-module/package.json
+++ b/packages/@cdk-cloudformation/org-test-sample-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/org-test-sample-module",
   "description": "Schema for Module Fragment of type ORG::TEST::SAMPLE::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy/package.json
+++ b/packages/@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy",
   "description": "Manage an escalation policy in PagerDuty.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/pagerduty-responseplays-responseplay/package.json
+++ b/packages/@cdk-cloudformation/pagerduty-responseplays-responseplay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/pagerduty-responseplays-responseplay",
   "description": "Manage a response play in PagerDuty",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/pagerduty-schedules-schedule/package.json
+++ b/packages/@cdk-cloudformation/pagerduty-schedules-schedule/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/pagerduty-schedules-schedule",
   "description": "Manage a on-call schedule in PagerDuty",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/pagerduty-teams-membership/package.json
+++ b/packages/@cdk-cloudformation/pagerduty-teams-membership/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/pagerduty-teams-membership",
   "description": "Manage a membership of a user into a team in PagerDuty.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/pagerduty-teams-team/package.json
+++ b/packages/@cdk-cloudformation/pagerduty-teams-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/pagerduty-teams-team",
   "description": "Manage a team in PagerDuty.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/pagerduty-users-user/package.json
+++ b/packages/@cdk-cloudformation/pagerduty-users-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/pagerduty-users-user",
   "description": "Manage a user in PagerDuty.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw/package.json
+++ b/packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw",
   "description": "A Firewall resource offers Palo Alto Networks next-generation firewall capabilities with built-in resiliency, scalability, and life-cycle management.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack/package.json
+++ b/packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack",
   "description": "A rulestack defines the NGFW's advanced access control (APP-ID, URL Filtering) and threat prevention behavior.",
-  "version": "1.1.0-alpha.6",
+  "version": "1.1.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/registry-test-resource1-module/package.json
+++ b/packages/@cdk-cloudformation/registry-test-resource1-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/registry-test-resource1-module",
   "description": "Schema for Module Fragment of type REGISTRY::TEST::RESOURCE::MODULE",
-  "version": "1.5.0-alpha.6",
+  "version": "1.5.0-alpha.7",
   "deprecated": true,
   "author": {
     "name": "Amazon Web Services",

--- a/packages/@cdk-cloudformation/rollbar-notifications-rule/package.json
+++ b/packages/@cdk-cloudformation/rollbar-notifications-rule/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/rollbar-notifications-rule",
   "description": "Manage a notification rule for Rollbar.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/rollbar-projects-accesstoken/package.json
+++ b/packages/@cdk-cloudformation/rollbar-projects-accesstoken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/rollbar-projects-accesstoken",
   "description": "Manage an access token for a Rollbar project.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/rollbar-projects-project/package.json
+++ b/packages/@cdk-cloudformation/rollbar-projects-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/rollbar-projects-project",
   "description": "Manage a project on Rollbar.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/rollbar-teams-membership/package.json
+++ b/packages/@cdk-cloudformation/rollbar-teams-membership/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/rollbar-teams-membership",
   "description": "Manage a team membership for a user or project on Rollbar.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/rollbar-teams-team/package.json
+++ b/packages/@cdk-cloudformation/rollbar-teams-team/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/rollbar-teams-team",
   "description": "Manage a team on Rollbar.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snowflake-database-database/package.json
+++ b/packages/@cdk-cloudformation/snowflake-database-database/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snowflake-database-database",
   "description": "Allows for the creation and modification of a Snowflake Database. https://docs.snowflake.com/en/user-guide/databases.html",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snowflake-database-grant/package.json
+++ b/packages/@cdk-cloudformation/snowflake-database-grant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snowflake-database-grant",
   "description": "Allows privileges to be granted on a database to a role. https://docs.snowflake.com/en/sql-reference/sql/grant-privilege.html",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snowflake-role-grant/package.json
+++ b/packages/@cdk-cloudformation/snowflake-role-grant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snowflake-role-grant",
   "description": "Allows privileges to be granted on a role to a user. https://docs.snowflake.com/en/sql-reference/sql/grant-privilege.html",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snowflake-role-role/package.json
+++ b/packages/@cdk-cloudformation/snowflake-role-role/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snowflake-role-role",
   "description": "Allows for the creation and modification of a Snowflake Role. https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snowflake-user-user/package.json
+++ b/packages/@cdk-cloudformation/snowflake-user-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snowflake-user-user",
   "description": "Allows for the creation and modification of a Snowflake User. https://docs.snowflake.com/en/user-guide/admin-user-management.html",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snowflake-warehouse-grant/package.json
+++ b/packages/@cdk-cloudformation/snowflake-warehouse-grant/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snowflake-warehouse-grant",
   "description": "Allows privileges to be granted on a warehouse to a role. https://docs.snowflake.com/en/sql-reference/sql/grant-privilege.html",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/snyk-container-helm/package.json
+++ b/packages/@cdk-cloudformation/snyk-container-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/snyk-container-helm",
   "description": "Snyk integrates with Amazon EKS, enabling you to import and test your running workloads and identify vulnerabilities in their associated images and configurations that might make those workloads less secure. Once imported, Snyk continues to monitor those workloads, identifying additional security issues as new images are deployed and the workload configuration changes.",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/package.json
+++ b/packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/splunk-enterprise-quickstart-module",
   "description": "Schema for Module Fragment of type Splunk::Enterprise::QuickStart::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/spot-elastigroup-group/package.json
+++ b/packages/@cdk-cloudformation/spot-elastigroup-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/spot-elastigroup-group",
   "description": "The Spot Elastigroup Resource allows you to create, update, manage, and delete Spot Elastigroups easily with CloudFormation",
-  "version": "1.0.3-alpha.6",
+  "version": "1.0.3-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/stackery-open-bastion-module/package.json
+++ b/packages/@cdk-cloudformation/stackery-open-bastion-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/stackery-open-bastion-module",
   "description": "Schema for Module Fragment of type Stackery::Open::Bastion::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/stocks-orders-marketorder/package.json
+++ b/packages/@cdk-cloudformation/stocks-orders-marketorder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/stocks-orders-marketorder",
   "description": "A market order is a request to buy or sell a security at the currently available market price. The order to buy a security will be submitted on resource creation and the security will be sold (or the unfilled order cancelled) on resource deletion. Supported exchanges are AMEX, ARCA, BATS, NYSE, NASDAQ and NYSEARCA.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/package.json
+++ b/packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module",
   "description": "Schema for Module Fragment of type Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/sysdig-helm-agent/package.json
+++ b/packages/@cdk-cloudformation/sysdig-helm-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/sysdig-helm-agent",
   "description": "Sysdig Agent EKS cluster deployment.",
-  "version": "1.8.0-alpha.6",
+  "version": "1.8.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-ad-computer/package.json
+++ b/packages/@cdk-cloudformation/tf-ad-computer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-ad-computer",
   "description": "CloudFormation equivalent of ad_computer",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-ad-user/package.json
+++ b/packages/@cdk-cloudformation/tf-ad-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-ad-user",
   "description": "CloudFormation equivalent of ad_user",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-aws-keypair/package.json
+++ b/packages/@cdk-cloudformation/tf-aws-keypair/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-aws-keypair",
   "description": "Provides an [EC2 key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) resource. A key pair is used to control login access to EC2 instances.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-aws-s3bucket/package.json
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-aws-s3bucket",
   "description": "Provides a S3 bucket resource.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-aws-s3bucketobject/package.json
+++ b/packages/@cdk-cloudformation/tf-aws-s3bucketobject/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-aws-s3bucketobject",
   "description": "Provides a S3 bucket object resource.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-azuread-application/package.json
+++ b/packages/@cdk-cloudformation/tf-azuread-application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-azuread-application",
   "description": "Manages an Application within Azure Active Directory.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-azuread-user/package.json
+++ b/packages/@cdk-cloudformation/tf-azuread-user/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-azuread-user",
   "description": "Manages a User within Azure Active Directory.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-cloudflare-record/package.json
+++ b/packages/@cdk-cloudformation/tf-cloudflare-record/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-cloudflare-record",
   "description": "Provides a Cloudflare record resource.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-digitalocean-droplet/package.json
+++ b/packages/@cdk-cloudformation/tf-digitalocean-droplet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-digitalocean-droplet",
   "description": "Provides a DigitalOcean Droplet resource. This can be used to create,",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-github-repository/package.json
+++ b/packages/@cdk-cloudformation/tf-github-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-github-repository",
   "description": "This resource allows you to create and manage repositories within your",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-google-storagebucket/package.json
+++ b/packages/@cdk-cloudformation/tf-google-storagebucket/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-google-storagebucket",
   "description": "Creates a new bucket in Google cloud storage service (GCS).",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-pagerduty-service/package.json
+++ b/packages/@cdk-cloudformation/tf-pagerduty-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-pagerduty-service",
   "description": "A [service](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/get_services) represents something you monitor (like a web service, email service, or database service). It is a container for related incidents that associates them with escalation policies.",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-random-string/package.json
+++ b/packages/@cdk-cloudformation/tf-random-string/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-random-string",
   "description": "CloudFormation equivalent of random_string",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/tf-random-uuid/package.json
+++ b/packages/@cdk-cloudformation/tf-random-uuid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/tf-random-uuid",
   "description": "CloudFormation equivalent of random_uuid",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/package.json
+++ b/packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/trendmicro-cloudonecontainer-helm",
   "description": "Deploys Trend Micro Cloud One Container Security into EKS clusters using helm.",
-  "version": "1.2.0-alpha.6",
+  "version": "1.2.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/packages/@cdk-cloudformation/zmk-iam-lambdabasicrole-module/package.json
+++ b/packages/@cdk-cloudformation/zmk-iam-lambdabasicrole-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cdk-cloudformation/zmk-iam-lambdabasicrole-module",
   "description": "Schema for Module Fragment of type zmk::IAM::LambdaBasicRole::MODULE",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "author": {
     "name": "Amazon Web Services",
     "url": "https://aws.amazon.com",

--- a/projenrc/update-registry.ts
+++ b/projenrc/update-registry.ts
@@ -73,6 +73,16 @@ export class UpdateRegistry extends Component {
               'labels': 'auto-approve',
             },
           },
+
+          // Auto-approve PR
+          {
+            uses: 'peter-evans/enable-pull-request-automerge@v2',
+            with: {
+              'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
+              'pull-request-number': '${{ steps.create-pr.outputs.pull-request-number }}',
+              'merge-method': 'squash',
+            },
+          },
         ],
       },
     });


### PR DESCRIPTION
Fixes packages deprecated by prefix are not marked as deprecated. They only stopped receiving updates from the registry.

Additionally changes the `update-registry` workflow to auto-merge since Mergify won't merge them if its own config has changed.