### PR TITLE
fix: update-registry auto-merge fails when no PR has been created

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -28,7 +28,8 @@ jobs:
           branch: automation/update-registry
           committer: GitHub Automation <noreply@github.com>
           labels: auto-approve
-      - uses: peter-evans/enable-pull-request-automerge@v2
+      - if: steps.create-pr.outputs.pull-request-number != 0
+        uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/projenrc/update-registry.ts
+++ b/projenrc/update-registry.ts
@@ -76,6 +76,7 @@ export class UpdateRegistry extends Component {
 
           // Auto-approve PR
           {
+            if: 'steps.create-pr.outputs.pull-request-number != 0',
             uses: 'peter-evans/enable-pull-request-automerge@v2',
             with: {
               'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',


### PR DESCRIPTION
Fixes failing GH Action when no Registry update was available. This has no functional impact, however failing Actions can create Ops overload.