### PR TITLE
fix: automerge step is not invoked

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -20,7 +20,8 @@ jobs:
           role-session-name: github-automation
       - run: yarn install
       - run: npx projen update-registry
-      - uses: peter-evans/create-pull-request@v4
+      - id: create-pr
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           title: "feat: cloudformation registry update"

--- a/projenrc/update-registry.ts
+++ b/projenrc/update-registry.ts
@@ -64,6 +64,7 @@ export class UpdateRegistry extends Component {
           // create a pull request
           {
             uses: 'peter-evans/create-pull-request@v4',
+            id: 'create-pr',
             with: {
               'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
               'title': 'feat: cloudformation registry update',


### PR DESCRIPTION
The automerge step depends on the condition `steps.create-pr.outputs.pull-request-number`, but the id `create-pr` was not set in for the create PR action.