### PR TITLE
chore: finding releasable commits should use a previous tag, not the new one

### DIFF
--- a/.github/workflows/release-alexa-ask-skill.yml
+++ b/.github/workflows/release-alexa-ask-skill.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/alexa-ask-skill@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Alexa::ASK::Skill` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Alexa::ASK::Skill to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/alexa-ask-skill
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/alexa-ask-skill@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/alexa-ask-skill
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-aqua-enterprise-enforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-enforcer.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/aqua-enterprise-enforcer@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Aqua::Enterprise::Enforcer` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Aqua::Enterprise::Enforcer to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-enforcer
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/aqua-enterprise-enforcer@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-enforcer
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/aqua-enterprise-kubeenforcer@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Aqua::Enterprise::KubeEnforcer` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Aqua::Enterprise::KubeEnforcer to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/aqua-enterprise-kubeenforcer@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-aqua-enterprise-scanner.yml
+++ b/.github/workflows/release-aqua-enterprise-scanner.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/aqua-enterprise-scanner@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Aqua::Enterprise::Scanner` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Aqua::Enterprise::Scanner to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-scanner
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/aqua-enterprise-scanner@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-scanner
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-aqua-enterprise-server.yml
+++ b/.github/workflows/release-aqua-enterprise-server.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/aqua-enterprise-server@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Aqua::Enterprise::Server` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Aqua::Enterprise::Server to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-server
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/aqua-enterprise-server@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/aqua-enterprise-server
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-atlassian-opsgenie-integration.yml
+++ b/.github/workflows/release-atlassian-opsgenie-integration.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/atlassian-opsgenie-integration@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Atlassian::Opsgenie::Integration` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Atlassian::Opsgenie::Integration to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/atlassian-opsgenie-integration
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/atlassian-opsgenie-integration@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/atlassian-opsgenie-integration
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-atlassian-opsgenie-team.yml
+++ b/.github/workflows/release-atlassian-opsgenie-team.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/atlassian-opsgenie-team@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Atlassian::Opsgenie::Team` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Atlassian::Opsgenie::Team to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/atlassian-opsgenie-team
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/atlassian-opsgenie-team@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/atlassian-opsgenie-team
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-atlassian-opsgenie-user.yml
+++ b/.github/workflows/release-atlassian-opsgenie-user.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/atlassian-opsgenie-user@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Atlassian::Opsgenie::User` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Atlassian::Opsgenie::User to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/atlassian-opsgenie-user
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/atlassian-opsgenie-user@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/atlassian-opsgenie-user
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-account-alternatecontact.yml
+++ b/.github/workflows/release-awscommunity-account-alternatecontact.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-account-alternatecontact@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::Account::AlternateContact` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::Account::AlternateContact to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-account-alternatecontact
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-account-alternatecontact@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-account-alternatecontact
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
+++ b/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-applicationautoscaling-scheduledaction@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::ApplicationAutoscaling::ScheduledAction` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::ApplicationAutoscaling::ScheduledAction to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-applicationautoscaling-scheduledaction
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-applicationautoscaling-scheduledaction@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-applicationautoscaling-scheduledaction
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
+++ b/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-cloudfront-s3website-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::CloudFront::S3Website::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::CloudFront::S3Website::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-cloudfront-s3website-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-cloudfront-s3website-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-cloudfront-s3website-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-dynamodb-item.yml
+++ b/.github/workflows/release-awscommunity-dynamodb-item.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-dynamodb-item@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::DynamoDB::Item` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::DynamoDB::Item to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-dynamodb-item
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-dynamodb-item@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-dynamodb-item
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-resource-lookup.yml
+++ b/.github/workflows/release-awscommunity-resource-lookup.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-resource-lookup@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::Resource::Lookup` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::Resource::Lookup to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-resource-lookup
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-resource-lookup@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-resource-lookup
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-s3-bucket-module.yml
+++ b/.github/workflows/release-awscommunity-s3-bucket-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-s3-bucket-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::S3::Bucket::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::S3::Bucket::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-s3-bucket-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-s3-bucket-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-s3-bucket-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
+++ b/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-s3-deletebucketcontents@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::S3::DeleteBucketContents` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::S3::DeleteBucketContents to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-s3-deletebucketcontents
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-s3-deletebucketcontents@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-s3-deletebucketcontents
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-time-offset.yml
+++ b/.github/workflows/release-awscommunity-time-offset.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-time-offset@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::Time::Offset` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::Time::Offset to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-time-offset
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-time-offset@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-time-offset
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-time-sleep.yml
+++ b/.github/workflows/release-awscommunity-time-sleep.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-time-sleep@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::Time::Sleep` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::Time::Sleep to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-time-sleep
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-time-sleep@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-time-sleep
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awscommunity-time-static.yml
+++ b/.github/workflows/release-awscommunity-time-static.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awscommunity-time-static@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AwsCommunity::Time::Static` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AwsCommunity::Time::Static to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awscommunity-time-static
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awscommunity-time-static@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awscommunity-time-static
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
+++ b/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::CheckPoint::CloudGuardQS::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::CheckPoint::CloudGuardQS::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
+++ b/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::EC2::LinuxBastionQS::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::EC2::LinuxBastionQS::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-eks-cluster.yml
+++ b/.github/workflows/release-awsqs-eks-cluster.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-eks-cluster@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::EKS::Cluster` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::EKS::Cluster to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-eks-cluster
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-eks-cluster@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-eks-cluster
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
+++ b/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::Iridium::CloudConnectQS::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::Iridium::CloudConnectQS::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-kubernetes-get.yml
+++ b/.github/workflows/release-awsqs-kubernetes-get.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-kubernetes-get@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::Kubernetes::Get` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::Kubernetes::Get to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-kubernetes-get
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-kubernetes-get@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-kubernetes-get
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-kubernetes-helm.yml
+++ b/.github/workflows/release-awsqs-kubernetes-helm.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-kubernetes-helm@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::Kubernetes::Helm` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::Kubernetes::Helm to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-kubernetes-helm
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-kubernetes-helm@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-kubernetes-helm
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-kubernetes-resource.yml
+++ b/.github/workflows/release-awsqs-kubernetes-resource.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-kubernetes-resource@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::Kubernetes::Resource` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::Kubernetes::Resource to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-kubernetes-resource
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-kubernetes-resource@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-kubernetes-resource
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
+++ b/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/awsqs-vpc-vpcqs-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `AWSQS::VPC::VPCQS::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type AWSQS::VPC::VPCQS::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/awsqs-vpc-vpcqs-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-bigid-datasource-dynamodb.yml
+++ b/.github/workflows/release-bigid-datasource-dynamodb.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/bigid-datasource-dynamodb@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `BigID::DataSource::DynamoDB` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type BigID::DataSource::DynamoDB to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/bigid-datasource-dynamodb
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/bigid-datasource-dynamodb@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/bigid-datasource-dynamodb
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-bigid-datasource-s3.yml
+++ b/.github/workflows/release-bigid-datasource-s3.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/bigid-datasource-s3@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `BigID::DataSource::S3` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type BigID::DataSource::S3 to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/bigid-datasource-s3
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/bigid-datasource-s3@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/bigid-datasource-s3
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-cadiaz-bucket-uno-module.yml
+++ b/.github/workflows/release-cadiaz-bucket-uno-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/cadiaz-bucket-uno-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Cadiaz::Bucket::Uno::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Cadiaz::Bucket::Uno::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/cadiaz-bucket-uno-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/cadiaz-bucket-uno-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/cadiaz-bucket-uno-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-cloudflare-dns-record.yml
+++ b/.github/workflows/release-cloudflare-dns-record.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/cloudflare-dns-record@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Cloudflare::Dns::Record` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Cloudflare::Dns::Record to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/cloudflare-dns-record
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/cloudflare-dns-record@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/cloudflare-dns-record
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Cloudflare::LoadBalancer::LoadBalancer` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Cloudflare::LoadBalancer::LoadBalancer to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/cloudflare-loadbalancer-monitor@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Cloudflare::LoadBalancer::Monitor` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Cloudflare::LoadBalancer::Monitor to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/cloudflare-loadbalancer-monitor
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/cloudflare-loadbalancer-monitor@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/cloudflare-loadbalancer-monitor
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-cloudflare-loadbalancer-pool.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-pool.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/cloudflare-loadbalancer-pool@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Cloudflare::LoadBalancer::Pool` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Cloudflare::LoadBalancer::Pool to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/cloudflare-loadbalancer-pool
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/cloudflare-loadbalancer-pool@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/cloudflare-loadbalancer-pool
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
+++ b/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/confluentcloud-iam-serviceaccount@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `ConfluentCloud::IAM::ServiceAccount` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type ConfluentCloud::IAM::ServiceAccount to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/confluentcloud-iam-serviceaccount
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/confluentcloud-iam-serviceaccount@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/confluentcloud-iam-serviceaccount
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-cyral-sidecar-deployment-module.yml
+++ b/.github/workflows/release-cyral-sidecar-deployment-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/cyral-sidecar-deployment-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Cyral::Sidecar::Deployment::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Cyral::Sidecar::Deployment::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/cyral-sidecar-deployment-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/cyral-sidecar-deployment-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/cyral-sidecar-deployment-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-databricks-clusters-cluster.yml
+++ b/.github/workflows/release-databricks-clusters-cluster.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/databricks-clusters-cluster@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Databricks::Clusters::Cluster` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Databricks::Clusters::Cluster to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/databricks-clusters-cluster
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/databricks-clusters-cluster@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/databricks-clusters-cluster
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-databricks-clusters-job.yml
+++ b/.github/workflows/release-databricks-clusters-job.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/databricks-clusters-job@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Databricks::Clusters::Job` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Databricks::Clusters::Job to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/databricks-clusters-job
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/databricks-clusters-job@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/databricks-clusters-job
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-datadog-dashboards-dashboard.yml
+++ b/.github/workflows/release-datadog-dashboards-dashboard.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/datadog-dashboards-dashboard@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Datadog::Dashboards::Dashboard` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Datadog::Dashboards::Dashboard to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/datadog-dashboards-dashboard
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/datadog-dashboards-dashboard@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/datadog-dashboards-dashboard
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-datadog-integrations-aws.yml
+++ b/.github/workflows/release-datadog-integrations-aws.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/datadog-integrations-aws@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Datadog::Integrations::AWS` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Datadog::Integrations::AWS to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/datadog-integrations-aws
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/datadog-integrations-aws@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/datadog-integrations-aws
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-datadog-monitors-downtime.yml
+++ b/.github/workflows/release-datadog-monitors-downtime.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/datadog-monitors-downtime@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Datadog::Monitors::Downtime` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Datadog::Monitors::Downtime to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/datadog-monitors-downtime
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/datadog-monitors-downtime@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/datadog-monitors-downtime
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-datadog-monitors-downtimeschedule.yml
+++ b/.github/workflows/release-datadog-monitors-downtimeschedule.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/datadog-monitors-downtimeschedule@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Datadog::Monitors::DowntimeSchedule` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Datadog::Monitors::DowntimeSchedule to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/datadog-monitors-downtimeschedule
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/datadog-monitors-downtimeschedule@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/datadog-monitors-downtimeschedule
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-datadog-monitors-monitor.yml
+++ b/.github/workflows/release-datadog-monitors-monitor.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/datadog-monitors-monitor@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Datadog::Monitors::Monitor` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Datadog::Monitors::Monitor to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/datadog-monitors-monitor
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/datadog-monitors-monitor@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/datadog-monitors-monitor
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-datadog-slos-slo.yml
+++ b/.github/workflows/release-datadog-slos-slo.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/datadog-slos-slo@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Datadog::SLOs::SLO` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Datadog::SLOs::SLO to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/datadog-slos-slo
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/datadog-slos-slo@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/datadog-slos-slo
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-dynatrace-configuration-dashboard.yml
+++ b/.github/workflows/release-dynatrace-configuration-dashboard.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/dynatrace-configuration-dashboard@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Dynatrace::Configuration::Dashboard` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Dynatrace::Configuration::Dashboard to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/dynatrace-configuration-dashboard
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/dynatrace-configuration-dashboard@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/dynatrace-configuration-dashboard
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-dynatrace-environment-metric.yml
+++ b/.github/workflows/release-dynatrace-environment-metric.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/dynatrace-environment-metric@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Dynatrace::Environment::Metric` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Dynatrace::Environment::Metric to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-metric
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/dynatrace-environment-metric@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-metric
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
+++ b/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/dynatrace-environment-servicelevelobjective@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Dynatrace::Environment::ServiceLevelObjective` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Dynatrace::Environment::ServiceLevelObjective to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-servicelevelobjective
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/dynatrace-environment-servicelevelobjective@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-servicelevelobjective
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/dynatrace-environment-syntheticlocation@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Dynatrace::Environment::SyntheticLocation` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Dynatrace::Environment::SyntheticLocation to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-syntheticlocation
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/dynatrace-environment-syntheticlocation@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-syntheticlocation
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/dynatrace-environment-syntheticmonitor@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Dynatrace::Environment::SyntheticMonitor` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Dynatrace::Environment::SyntheticMonitor to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-syntheticmonitor
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/dynatrace-environment-syntheticmonitor@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/dynatrace-environment-syntheticmonitor
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-dictionary-dictionary.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionary.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-dictionary-dictionary@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Dictionary::Dictionary` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Dictionary::Dictionary to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-dictionary-dictionary
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-dictionary-dictionary@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-dictionary-dictionary
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-dictionary-dictionaryitem@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Dictionary::DictionaryItem` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Dictionary::DictionaryItem to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-dictionary-dictionaryitem
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-dictionary-dictionaryitem@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-dictionary-dictionaryitem
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-logging-s3.yml
+++ b/.github/workflows/release-fastly-logging-s3.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-logging-s3@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Logging::S3` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Logging::S3 to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-logging-s3
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-logging-s3@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-logging-s3
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-logging-splunk.yml
+++ b/.github/workflows/release-fastly-logging-splunk.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-logging-splunk@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Logging::Splunk` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Logging::Splunk to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-logging-splunk
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-logging-splunk@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-logging-splunk
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-services-activeversion.yml
+++ b/.github/workflows/release-fastly-services-activeversion.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-services-activeversion@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Services::ActiveVersion` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Services::ActiveVersion to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-services-activeversion
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-services-activeversion@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-services-activeversion
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-services-backend.yml
+++ b/.github/workflows/release-fastly-services-backend.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-services-backend@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Services::Backend` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Services::Backend to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-services-backend
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-services-backend@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-services-backend
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-services-domain.yml
+++ b/.github/workflows/release-fastly-services-domain.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-services-domain@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Services::Domain` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Services::Domain to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-services-domain
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-services-domain@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-services-domain
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-services-healthcheck.yml
+++ b/.github/workflows/release-fastly-services-healthcheck.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-services-healthcheck@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Services::Healthcheck` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Services::Healthcheck to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-services-healthcheck
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-services-healthcheck@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-services-healthcheck
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-services-service.yml
+++ b/.github/workflows/release-fastly-services-service.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-services-service@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Services::Service` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Services::Service to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-services-service
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-services-service@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-services-service
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-services-version.yml
+++ b/.github/workflows/release-fastly-services-version.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-services-version@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Services::Version` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Services::Version to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-services-version
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-services-version@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-services-version
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-tls-certificate.yml
+++ b/.github/workflows/release-fastly-tls-certificate.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-tls-certificate@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Tls::Certificate` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Tls::Certificate to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-tls-certificate
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-tls-certificate@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-tls-certificate
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-tls-domain.yml
+++ b/.github/workflows/release-fastly-tls-domain.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-tls-domain@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Tls::Domain` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Tls::Domain to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-tls-domain
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-tls-domain@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-tls-domain
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fastly-tls-privatekeys.yml
+++ b/.github/workflows/release-fastly-tls-privatekeys.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fastly-tls-privatekeys@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Fastly::Tls::PrivateKeys` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Fastly::Tls::PrivateKeys to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fastly-tls-privatekeys
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fastly-tls-privatekeys@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fastly-tls-privatekeys
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
+++ b/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FireEye::CloudIntegrations::Cloudwatch` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FireEye::CloudIntegrations::Cloudwatch to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-impactapi-apigateway-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::ImpactApi::ApiGateway::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::ImpactApi::ApiGateway::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-apigateway-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-impactapi-apigateway-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-apigateway-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-impactapi-apihandle-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::ImpactApi::ApiHandle::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::ImpactApi::ApiHandle::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-apihandle-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-impactapi-apihandle-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-apihandle-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-impactapi-ec2instance-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::ImpactApi::EC2Instance::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::ImpactApi::EC2Instance::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-ec2instance-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-impactapi-ec2instance-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-ec2instance-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-impactapi-lambdafunction-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::ImpactApi::LambdaFunction::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::ImpactApi::LambdaFunction::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-lambdafunction-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-impactapi-lambdafunction-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-lambdafunction-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-impactapi-loadbalancer-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::ImpactApi::LoadBalancer::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::ImpactApi::LoadBalancer::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-loadbalancer-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-impactapi-loadbalancer-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-impactapi-loadbalancer-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-spider-cloudfront-module.yml
+++ b/.github/workflows/release-freyraim-spider-cloudfront-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-spider-cloudfront-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::Spider::CloudFront::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::Spider::CloudFront::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-spider-cloudfront-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-spider-cloudfront-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-spider-cloudfront-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-spider-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-spider-ec2instance-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-spider-ec2instance-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::Spider::EC2Instance::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::Spider::EC2Instance::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-spider-ec2instance-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-spider-ec2instance-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-spider-ec2instance-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-spider-ecs-module.yml
+++ b/.github/workflows/release-freyraim-spider-ecs-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-spider-ecs-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::Spider::ECS::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::Spider::ECS::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-spider-ecs-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-spider-ecs-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-spider-ecs-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-spider-loadbalancer-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::Spider::LoadBalancer::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::Spider::LoadBalancer::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-spider-loadbalancer-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-spider-loadbalancer-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-spider-loadbalancer-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-spider-postgresql-module.yml
+++ b/.github/workflows/release-freyraim-spider-postgresql-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-spider-postgresql-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::Spider::PostgreSQL::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::Spider::PostgreSQL::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-spider-postgresql-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-spider-postgresql-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-spider-postgresql-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-freyraim-spider-s3bucket-module.yml
+++ b/.github/workflows/release-freyraim-spider-s3bucket-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/freyraim-spider-s3bucket-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `FreyrAIM::Spider::S3Bucket::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type FreyrAIM::Spider::S3Bucket::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/freyraim-spider-s3bucket-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/freyraim-spider-s3bucket-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/freyraim-spider-s3bucket-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-generic-database-schema.yml
+++ b/.github/workflows/release-generic-database-schema.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/generic-database-schema@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Generic::Database::Schema` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Generic::Database::Schema to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/generic-database-schema
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/generic-database-schema@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/generic-database-schema
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-generic-transcribe-vocabulary.yml
+++ b/.github/workflows/release-generic-transcribe-vocabulary.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/generic-transcribe-vocabulary@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Generic::Transcribe::Vocabulary` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Generic::Transcribe::Vocabulary to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/generic-transcribe-vocabulary
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/generic-transcribe-vocabulary@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/generic-transcribe-vocabulary
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-git-tag.yml
+++ b/.github/workflows/release-github-git-tag.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-git-tag@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Git::Tag` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Git::Tag to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-git-tag
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-git-tag@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-git-tag
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-organizations-membership.yml
+++ b/.github/workflows/release-github-organizations-membership.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-organizations-membership@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Organizations::Membership` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Organizations::Membership to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-organizations-membership
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-organizations-membership@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-organizations-membership
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-organizations-secret.yml
+++ b/.github/workflows/release-github-organizations-secret.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-organizations-secret@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Organizations::Secret` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Organizations::Secret to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-organizations-secret
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-organizations-secret@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-organizations-secret
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-repositories-collaborator.yml
+++ b/.github/workflows/release-github-repositories-collaborator.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-repositories-collaborator@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Repositories::Collaborator` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Repositories::Collaborator to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-repositories-collaborator
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-repositories-collaborator@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-repositories-collaborator
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-repositories-repository.yml
+++ b/.github/workflows/release-github-repositories-repository.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-repositories-repository@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Repositories::Repository` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Repositories::Repository to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-repositories-repository
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-repositories-repository@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-repositories-repository
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-repositories-secret.yml
+++ b/.github/workflows/release-github-repositories-secret.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-repositories-secret@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Repositories::Secret` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Repositories::Secret to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-repositories-secret
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-repositories-secret@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-repositories-secret
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-repositories-webhook.yml
+++ b/.github/workflows/release-github-repositories-webhook.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-repositories-webhook@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Repositories::Webhook` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Repositories::Webhook to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-repositories-webhook
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-repositories-webhook@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-repositories-webhook
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-teams-membership.yml
+++ b/.github/workflows/release-github-teams-membership.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-teams-membership@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Teams::Membership` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Teams::Membership to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-teams-membership
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-teams-membership@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-teams-membership
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-teams-repositoryaccess.yml
+++ b/.github/workflows/release-github-teams-repositoryaccess.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-teams-repositoryaccess@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Teams::RepositoryAccess` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Teams::RepositoryAccess to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-teams-repositoryaccess
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-teams-repositoryaccess@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-teams-repositoryaccess
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-github-teams-team.yml
+++ b/.github/workflows/release-github-teams-team.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/github-teams-team@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitHub::Teams::Team` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitHub::Teams::Team to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/github-teams-team
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/github-teams-team@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/github-teams-team
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-code-tag.yml
+++ b/.github/workflows/release-gitlab-code-tag.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-code-tag@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Code::Tag` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Code::Tag to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-code-tag
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-code-tag@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-code-tag
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-groups-group.yml
+++ b/.github/workflows/release-gitlab-groups-group.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-groups-group@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Groups::Group` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Groups::Group to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-groups-group
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-groups-group@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-groups-group
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
+++ b/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-groups-groupaccesstogroup@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Groups::GroupAccessToGroup` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Groups::GroupAccessToGroup to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-groups-groupaccesstogroup
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-groups-groupaccesstogroup@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-groups-groupaccesstogroup
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
+++ b/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-groups-usermemberofgroup@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Groups::UserMemberOfGroup` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Groups::UserMemberOfGroup to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-groups-usermemberofgroup
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-groups-usermemberofgroup@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-groups-usermemberofgroup
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-projects-accesstoken.yml
+++ b/.github/workflows/release-gitlab-projects-accesstoken.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-projects-accesstoken@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Projects::AccessToken` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Projects::AccessToken to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-projects-accesstoken
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-projects-accesstoken@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-projects-accesstoken
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
+++ b/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-projects-groupaccesstoproject@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Projects::GroupAccessToProject` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Projects::GroupAccessToProject to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-projects-groupaccesstoproject
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-projects-groupaccesstoproject@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-projects-groupaccesstoproject
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-projects-project.yml
+++ b/.github/workflows/release-gitlab-projects-project.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-projects-project@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Projects::Project` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Projects::Project to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-projects-project
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-projects-project@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-projects-project
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gitlab-projects-usermemberofproject.yml
+++ b/.github/workflows/release-gitlab-projects-usermemberofproject.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gitlab-projects-usermemberofproject@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `GitLab::Projects::UserMemberOfProject` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type GitLab::Projects::UserMemberOfProject to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gitlab-projects-usermemberofproject
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gitlab-projects-usermemberofproject@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gitlab-projects-usermemberofproject
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-gremlin-agent-helm.yml
+++ b/.github/workflows/release-gremlin-agent-helm.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/gremlin-agent-helm@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Gremlin::Agent::Helm` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Gremlin::Agent::Helm to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/gremlin-agent-helm
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/gremlin-agent-helm@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/gremlin-agent-helm
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-artifactory-core-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-core-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-artifactory-core-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Artifactory::Core::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Artifactory::Core::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-core-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-artifactory-core-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-core-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-artifactory-ec2instance-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Artifactory::EC2Instance::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Artifactory::EC2Instance::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-artifactory-ec2instance-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-artifactory-existingvpc-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Artifactory::ExistingVpc::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Artifactory::ExistingVpc::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-artifactory-existingvpc-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-artifactory-newvpc-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Artifactory::NewVpc::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Artifactory::NewVpc::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-artifactory-newvpc-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-linux-bastion-module.yml
+++ b/.github/workflows/release-jfrog-linux-bastion-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-linux-bastion-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Linux::Bastion::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Linux::Bastion::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-linux-bastion-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-linux-bastion-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-linux-bastion-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-vpc-multiaz-module.yml
+++ b/.github/workflows/release-jfrog-vpc-multiaz-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-vpc-multiaz-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Vpc::MultiAz::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Vpc::MultiAz::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-vpc-multiaz-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-vpc-multiaz-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-vpc-multiaz-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-jfrog-xray-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-xray-ec2instance-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/jfrog-xray-ec2instance-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `JFrog::Xray::EC2Instance::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type JFrog::Xray::EC2Instance::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/jfrog-xray-ec2instance-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/jfrog-xray-ec2instance-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/jfrog-xray-ec2instance-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-karte-eventbridge-documentdb-module.yml
+++ b/.github/workflows/release-karte-eventbridge-documentdb-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/karte-eventbridge-documentdb-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `KARTE::EventBridge::DocumentDB::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type KARTE::EventBridge::DocumentDB::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/karte-eventbridge-documentdb-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/karte-eventbridge-documentdb-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/karte-eventbridge-documentdb-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
+++ b/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `logzio::autoDeploymentLogzio::CloudWatch::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type logzio::autoDeploymentLogzio::CloudWatch::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-logzio-awscostandusage-cur-module.yml
+++ b/.github/workflows/release-logzio-awscostandusage-cur-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/logzio-awscostandusage-cur-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Logzio::awsCostAndUsage::cur::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Logzio::awsCostAndUsage::cur::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/logzio-awscostandusage-cur-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/logzio-awscostandusage-cur-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/logzio-awscostandusage-cur-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
+++ b/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/logzio-awssecurityhub-collector-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `logzio::awsSecurityHub::collector::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type logzio::awsSecurityHub::collector::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/logzio-awssecurityhub-collector-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
+++ b/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Logzio::KinesisShipper::KinesisShipper::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Logzio::KinesisShipper::KinesisShipper::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-logzio-myservice-myname-module.yml
+++ b/.github/workflows/release-logzio-myservice-myname-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/logzio-myservice-myname-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Logzio::MyService::MyName::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Logzio::MyService::MyName::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/logzio-myservice-myname-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/logzio-myservice-myname-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/logzio-myservice-myname-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-mavi-pipeline-default-module.yml
+++ b/.github/workflows/release-mavi-pipeline-default-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/mavi-pipeline-default-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `MAVI::Pipeline::Default::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type MAVI::Pipeline::Default::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/mavi-pipeline-default-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/mavi-pipeline-default-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/mavi-pipeline-default-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-mongodb-atlas-cluster.yml
+++ b/.github/workflows/release-mongodb-atlas-cluster.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/mongodb-atlas-cluster@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `MongoDB::Atlas::Cluster` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type MongoDB::Atlas::Cluster to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-cluster
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/mongodb-atlas-cluster@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-cluster
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-mongodb-atlas-databaseuser.yml
+++ b/.github/workflows/release-mongodb-atlas-databaseuser.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/mongodb-atlas-databaseuser@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `MongoDB::Atlas::DatabaseUser` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type MongoDB::Atlas::DatabaseUser to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-databaseuser
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/mongodb-atlas-databaseuser@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-databaseuser
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-mongodb-atlas-networkpeering.yml
+++ b/.github/workflows/release-mongodb-atlas-networkpeering.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/mongodb-atlas-networkpeering@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `MongoDB::Atlas::NetworkPeering` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type MongoDB::Atlas::NetworkPeering to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-networkpeering
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/mongodb-atlas-networkpeering@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-networkpeering
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-mongodb-atlas-project.yml
+++ b/.github/workflows/release-mongodb-atlas-project.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/mongodb-atlas-project@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `MongoDB::Atlas::Project` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type MongoDB::Atlas::Project to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-project
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/mongodb-atlas-project@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-project
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
+++ b/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/mongodb-atlas-projectipaccesslist@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `MongoDB::Atlas::ProjectIpAccessList` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type MongoDB::Atlas::ProjectIpAccessList to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/mongodb-atlas-projectipaccesslist@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-agent-configuration.yml
+++ b/.github/workflows/release-newrelic-agent-configuration.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-agent-configuration@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Agent::Configuration` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Agent::Configuration to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-agent-configuration
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-agent-configuration@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-agent-configuration
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-alert-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-alert-alertspolicy.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-alert-alertspolicy@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Alert::AlertsPolicy` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Alert::AlertsPolicy to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-alert-alertspolicy
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-alert-alertspolicy@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-alert-alertspolicy
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
+++ b/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-alert-nrqlconditionstatic@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Alert::NrqlConditionStatic` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Alert::NrqlConditionStatic to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-alert-nrqlconditionstatic
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-alert-nrqlconditionstatic@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-alert-nrqlconditionstatic
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-cloudformation-dashboards.yml
+++ b/.github/workflows/release-newrelic-cloudformation-dashboards.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-cloudformation-dashboards@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `newrelic::cloudformation::dashboards` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type newrelic::cloudformation::dashboards to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-cloudformation-dashboards
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-cloudformation-dashboards@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-cloudformation-dashboards
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-cloudformation-tagging.yml
+++ b/.github/workflows/release-newrelic-cloudformation-tagging.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-cloudformation-tagging@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `newrelic::cloudformation::tagging` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type newrelic::cloudformation::tagging to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-cloudformation-tagging
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-cloudformation-tagging@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-cloudformation-tagging
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-cloudformation-workloads.yml
+++ b/.github/workflows/release-newrelic-cloudformation-workloads.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-cloudformation-workloads@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::CloudFormation::Workloads` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::CloudFormation::Workloads to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-cloudformation-workloads
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-cloudformation-workloads@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-cloudformation-workloads
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-ainotificationschannel@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::AINotificationsChannel` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::AINotificationsChannel to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-ainotificationschannel
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-ainotificationschannel@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-ainotificationschannel
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-ainotificationsdestination@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::AINotificationsDestination` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::AINotificationsDestination to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-ainotificationsdestination
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-ainotificationsdestination@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-ainotificationsdestination
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-aiworkflows.yml
+++ b/.github/workflows/release-newrelic-observability-aiworkflows.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-aiworkflows@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::AIWorkflows` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::AIWorkflows to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-aiworkflows
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-aiworkflows@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-aiworkflows
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
+++ b/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-alertsmutingrule@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::AlertsMutingRule` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::AlertsMutingRule to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-alertsmutingrule
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-alertsmutingrule@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-alertsmutingrule
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
+++ b/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-alertsnrqlcondition@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::AlertsNrqlCondition` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::AlertsNrqlCondition to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-alertsnrqlcondition
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-alertsnrqlcondition@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-alertsnrqlcondition
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-observability-alertspolicy.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-alertspolicy@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::AlertsPolicy` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::AlertsPolicy to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-alertspolicy
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-alertspolicy@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-alertspolicy
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-dashboards.yml
+++ b/.github/workflows/release-newrelic-observability-dashboards.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-dashboards@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::Dashboards` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::Dashboards to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-dashboards
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-dashboards@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-dashboards
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-newrelic-observability-workloads.yml
+++ b/.github/workflows/release-newrelic-observability-workloads.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/newrelic-observability-workloads@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `NewRelic::Observability::Workloads` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type NewRelic::Observability::Workloads to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/newrelic-observability-workloads
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/newrelic-observability-workloads@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/newrelic-observability-workloads
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-okta-application-application.yml
+++ b/.github/workflows/release-okta-application-application.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/okta-application-application@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Okta::Application::Application` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Okta::Application::Application to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/okta-application-application
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/okta-application-application@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/okta-application-application
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-okta-group-group.yml
+++ b/.github/workflows/release-okta-group-group.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/okta-group-group@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Okta::Group::Group` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Okta::Group::Group to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/okta-group-group
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/okta-group-group@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/okta-group-group
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-okta-group-groupapplicationassociation.yml
+++ b/.github/workflows/release-okta-group-groupapplicationassociation.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/okta-group-groupapplicationassociation@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Okta::Group::GroupApplicationAssociation` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Okta::Group::GroupApplicationAssociation to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/okta-group-groupapplicationassociation
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/okta-group-groupapplicationassociation@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/okta-group-groupapplicationassociation
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-okta-group-membership.yml
+++ b/.github/workflows/release-okta-group-membership.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/okta-group-membership@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Okta::Group::Membership` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Okta::Group::Membership to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/okta-group-membership
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/okta-group-membership@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/okta-group-membership
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-okta-policy-policy.yml
+++ b/.github/workflows/release-okta-policy-policy.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/okta-policy-policy@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Okta::Policy::Policy` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Okta::Policy::Policy to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/okta-policy-policy
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/okta-policy-policy@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/okta-policy-policy
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-org-test-sample-module.yml
+++ b/.github/workflows/release-org-test-sample-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/org-test-sample-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `ORG::TEST::SAMPLE::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type ORG::TEST::SAMPLE::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/org-test-sample-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/org-test-sample-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/org-test-sample-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
+++ b/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PagerDuty::EscalationPolicies::EscalationPolicy` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PagerDuty::EscalationPolicies::EscalationPolicy to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-pagerduty-responseplays-responseplay.yml
+++ b/.github/workflows/release-pagerduty-responseplays-responseplay.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/pagerduty-responseplays-responseplay@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PagerDuty::ResponsePlays::ResponsePlay` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PagerDuty::ResponsePlays::ResponsePlay to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/pagerduty-responseplays-responseplay
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/pagerduty-responseplays-responseplay@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/pagerduty-responseplays-responseplay
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-pagerduty-schedules-schedule.yml
+++ b/.github/workflows/release-pagerduty-schedules-schedule.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/pagerduty-schedules-schedule@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PagerDuty::Schedules::Schedule` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PagerDuty::Schedules::Schedule to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/pagerduty-schedules-schedule
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/pagerduty-schedules-schedule@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/pagerduty-schedules-schedule
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-pagerduty-teams-membership.yml
+++ b/.github/workflows/release-pagerduty-teams-membership.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/pagerduty-teams-membership@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PagerDuty::Teams::Membership` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PagerDuty::Teams::Membership to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/pagerduty-teams-membership
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/pagerduty-teams-membership@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/pagerduty-teams-membership
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-pagerduty-teams-team.yml
+++ b/.github/workflows/release-pagerduty-teams-team.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/pagerduty-teams-team@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PagerDuty::Teams::Team` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PagerDuty::Teams::Team to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/pagerduty-teams-team
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/pagerduty-teams-team@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/pagerduty-teams-team
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-pagerduty-users-user.yml
+++ b/.github/workflows/release-pagerduty-users-user.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/pagerduty-users-user@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PagerDuty::Users::User` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PagerDuty::Users::User to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/pagerduty-users-user
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/pagerduty-users-user@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/pagerduty-users-user
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PaloAltoNetworks::CloudNGFW::NGFW` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PaloAltoNetworks::CloudNGFW::NGFW to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `PaloAltoNetworks::CloudNGFW::RuleStack` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type PaloAltoNetworks::CloudNGFW::RuleStack to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-poc-azure-blobstorage.yml
+++ b/.github/workflows/release-poc-azure-blobstorage.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/poc-azure-blobstorage@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `POC::Azure::BlobStorage` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type POC::Azure::BlobStorage to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/poc-azure-blobstorage
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/poc-azure-blobstorage@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/poc-azure-blobstorage
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-registry-test-resource1-module.yml
+++ b/.github/workflows/release-registry-test-resource1-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/registry-test-resource1-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `REGISTRY::TEST::RESOURCE1::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type REGISTRY::TEST::RESOURCE1::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/registry-test-resource1-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/registry-test-resource1-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/registry-test-resource1-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-rollbar-notifications-rule.yml
+++ b/.github/workflows/release-rollbar-notifications-rule.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/rollbar-notifications-rule@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Rollbar::Notifications::Rule` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Rollbar::Notifications::Rule to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/rollbar-notifications-rule
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/rollbar-notifications-rule@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/rollbar-notifications-rule
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-rollbar-projects-accesstoken.yml
+++ b/.github/workflows/release-rollbar-projects-accesstoken.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/rollbar-projects-accesstoken@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Rollbar::Projects::AccessToken` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Rollbar::Projects::AccessToken to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/rollbar-projects-accesstoken
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/rollbar-projects-accesstoken@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/rollbar-projects-accesstoken
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-rollbar-projects-project.yml
+++ b/.github/workflows/release-rollbar-projects-project.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/rollbar-projects-project@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Rollbar::Projects::Project` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Rollbar::Projects::Project to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/rollbar-projects-project
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/rollbar-projects-project@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/rollbar-projects-project
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-rollbar-teams-membership.yml
+++ b/.github/workflows/release-rollbar-teams-membership.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/rollbar-teams-membership@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Rollbar::Teams::Membership` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Rollbar::Teams::Membership to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/rollbar-teams-membership
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/rollbar-teams-membership@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/rollbar-teams-membership
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-rollbar-teams-team.yml
+++ b/.github/workflows/release-rollbar-teams-team.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/rollbar-teams-team@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Rollbar::Teams::Team` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Rollbar::Teams::Team to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/rollbar-teams-team
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/rollbar-teams-team@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/rollbar-teams-team
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snowflake-database-database.yml
+++ b/.github/workflows/release-snowflake-database-database.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snowflake-database-database@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snowflake::Database::Database` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snowflake::Database::Database to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snowflake-database-database
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snowflake-database-database@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snowflake-database-database
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snowflake-database-grant.yml
+++ b/.github/workflows/release-snowflake-database-grant.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snowflake-database-grant@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snowflake::Database::Grant` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snowflake::Database::Grant to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snowflake-database-grant
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snowflake-database-grant@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snowflake-database-grant
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snowflake-role-grant.yml
+++ b/.github/workflows/release-snowflake-role-grant.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snowflake-role-grant@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snowflake::Role::Grant` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snowflake::Role::Grant to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snowflake-role-grant
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snowflake-role-grant@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snowflake-role-grant
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snowflake-role-role.yml
+++ b/.github/workflows/release-snowflake-role-role.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snowflake-role-role@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snowflake::Role::Role` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snowflake::Role::Role to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snowflake-role-role
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snowflake-role-role@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snowflake-role-role
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snowflake-user-user.yml
+++ b/.github/workflows/release-snowflake-user-user.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snowflake-user-user@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snowflake::User::User` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snowflake::User::User to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snowflake-user-user
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snowflake-user-user@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snowflake-user-user
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snowflake-warehouse-grant.yml
+++ b/.github/workflows/release-snowflake-warehouse-grant.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snowflake-warehouse-grant@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snowflake::Warehouse::Grant` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snowflake::Warehouse::Grant to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snowflake-warehouse-grant
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snowflake-warehouse-grant@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snowflake-warehouse-grant
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-snyk-container-helm.yml
+++ b/.github/workflows/release-snyk-container-helm.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/snyk-container-helm@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Snyk::Container::Helm` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Snyk::Container::Helm to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/snyk-container-helm
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/snyk-container-helm@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/snyk-container-helm
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-splunk-enterprise-quickstart-module.yml
+++ b/.github/workflows/release-splunk-enterprise-quickstart-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/splunk-enterprise-quickstart-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Splunk::Enterprise::QuickStart::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Splunk::Enterprise::QuickStart::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/splunk-enterprise-quickstart-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/splunk-enterprise-quickstart-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/splunk-enterprise-quickstart-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-spot-elastigroup-group.yml
+++ b/.github/workflows/release-spot-elastigroup-group.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/spot-elastigroup-group@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Spot::Elastigroup::Group` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Spot::Elastigroup::Group to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/spot-elastigroup-group
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/spot-elastigroup-group@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/spot-elastigroup-group
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-stackery-open-bastion-module.yml
+++ b/.github/workflows/release-stackery-open-bastion-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/stackery-open-bastion-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Stackery::Open::Bastion::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Stackery::Open::Bastion::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/stackery-open-bastion-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/stackery-open-bastion-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/stackery-open-bastion-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-stocks-orders-marketorder.yml
+++ b/.github/workflows/release-stocks-orders-marketorder.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/stocks-orders-marketorder@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Stocks::Orders::MarketOrder` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Stocks::Orders::MarketOrder to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/stocks-orders-marketorder
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/stocks-orders-marketorder@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/stocks-orders-marketorder
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
+++ b/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Symphonia::OpenSource::CloudFormationArtifactsBucket::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-sysdig-helm-agent.yml
+++ b/.github/workflows/release-sysdig-helm-agent.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/sysdig-helm-agent@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Sysdig::Helm::Agent` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Sysdig::Helm::Agent to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/sysdig-helm-agent
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/sysdig-helm-agent@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/sysdig-helm-agent
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-ad-computer.yml
+++ b/.github/workflows/release-tf-ad-computer.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-ad-computer@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AD::Computer` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AD::Computer to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-ad-computer
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-ad-computer@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-ad-computer
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-ad-user.yml
+++ b/.github/workflows/release-tf-ad-user.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-ad-user@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AD::User` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AD::User to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-ad-user
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-ad-user@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-ad-user
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-aws-keypair.yml
+++ b/.github/workflows/release-tf-aws-keypair.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-aws-keypair@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AWS::KeyPair` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AWS::KeyPair to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-aws-keypair
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-aws-keypair@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-aws-keypair
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-aws-s3bucket.yml
+++ b/.github/workflows/release-tf-aws-s3bucket.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-aws-s3bucket@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AWS::S3Bucket` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AWS::S3Bucket to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-aws-s3bucket
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-aws-s3bucket@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-aws-s3bucket
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-aws-s3bucketobject.yml
+++ b/.github/workflows/release-tf-aws-s3bucketobject.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-aws-s3bucketobject@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AWS::S3BucketObject` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AWS::S3BucketObject to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-aws-s3bucketobject
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-aws-s3bucketobject@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-aws-s3bucketobject
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-azuread-application.yml
+++ b/.github/workflows/release-tf-azuread-application.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-azuread-application@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AzureAD::Application` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AzureAD::Application to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-azuread-application
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-azuread-application@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-azuread-application
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-azuread-user.yml
+++ b/.github/workflows/release-tf-azuread-user.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-azuread-user@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::AzureAD::User` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::AzureAD::User to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-azuread-user
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-azuread-user@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-azuread-user
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-cloudflare-record.yml
+++ b/.github/workflows/release-tf-cloudflare-record.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-cloudflare-record@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::Cloudflare::Record` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::Cloudflare::Record to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-cloudflare-record
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-cloudflare-record@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-cloudflare-record
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-digitalocean-droplet.yml
+++ b/.github/workflows/release-tf-digitalocean-droplet.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-digitalocean-droplet@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::DigitalOcean::Droplet` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::DigitalOcean::Droplet to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-digitalocean-droplet
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-digitalocean-droplet@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-digitalocean-droplet
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-github-repository.yml
+++ b/.github/workflows/release-tf-github-repository.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-github-repository@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::GitHub::Repository` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::GitHub::Repository to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-github-repository
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-github-repository@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-github-repository
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-google-storagebucket.yml
+++ b/.github/workflows/release-tf-google-storagebucket.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-google-storagebucket@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::Google::StorageBucket` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::Google::StorageBucket to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-google-storagebucket
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-google-storagebucket@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-google-storagebucket
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-pagerduty-service.yml
+++ b/.github/workflows/release-tf-pagerduty-service.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-pagerduty-service@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::PagerDuty::Service` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::PagerDuty::Service to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-pagerduty-service
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-pagerduty-service@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-pagerduty-service
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-random-string.yml
+++ b/.github/workflows/release-tf-random-string.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-random-string@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::Random::String` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::Random::String to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-random-string
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-random-string@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-random-string
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-tf-random-uuid.yml
+++ b/.github/workflows/release-tf-random-uuid.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/tf-random-uuid@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TF::Random::Uuid` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TF::Random::Uuid to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/tf-random-uuid
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/tf-random-uuid@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/tf-random-uuid
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
+++ b/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/trendmicro-cloudonecontainer-helm@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `TrendMicro::CloudOneContainer::Helm` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type TrendMicro::CloudOneContainer::Helm to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/trendmicro-cloudonecontainer-helm@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-unxpose-iam-integration-module.yml
+++ b/.github/workflows/release-unxpose-iam-integration-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/unxpose-iam-integration-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `Unxpose::IAM::Integration::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type Unxpose::IAM::Integration::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/unxpose-iam-integration-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/unxpose-iam-integration-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/unxpose-iam-integration-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
+++ b/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
@@ -29,13 +29,14 @@ jobs:
         run: |-
           echo $(node -p "require('./package.json').version") > dist/version.txt
           echo "@cdk-cloudformation/zmk-iam-lambdabasicrole-module@v$(cat dist/version.txt)" > dist/releasetag.txt
-          echo "Update AWS CloudFormation Registry type `zmk::IAM::LambdaBasicRole::MODULE` to v$(cat dist/version.txt)" > dist/changelog.txt
+          echo "Update AWS CloudFormation Registry type zmk::IAM::LambdaBasicRole::MODULE to v$(cat dist/version.txt)" > dist/changelog.txt
         working-directory: packages/@cdk-cloudformation/zmk-iam-lambdabasicrole-module
       - name: Check for releasable commits
         id: check-commits
         run: |-
-          LATEST_TAG=$(cat dist/releasetag.txt)
-          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | sed -n '$=')
+          LATEST_TAG=$(git -c "versionsort.suffix=-" tag --sort="-version:refname" --list "@cdk-cloudformation/zmk-iam-lambdabasicrole-module@v*" | head -n 1)
+          echo ${LATEST_TAG:=$(git rev-list HEAD -- . | tail -1)^}
+          COUNT=$(git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\([^()[:space:]]+\))?(!)?:[[:blank:]]+.+' -- . | wc -l | xargs)
           echo "releasable_count=$COUNT" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
         working-directory: packages/@cdk-cloudformation/zmk-iam-lambdabasicrole-module
@@ -62,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -87,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -111,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:
@@ -137,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: (needs.build.outputs.tag_exists != 'true') && (fromJSON(needs.build.outputs.releasable_commits) > 0)
+    if: (needs.build.outputs.tag_exists != 'true') && (needs.build.outputs.releasable_commits > 0)
     steps:
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This was a stupid mistake on my part in #513 