### PR TITLE
chore: shallow checkout prevents release checker

### DIFF
--- a/.github/workflows/release-alexa-ask-skill.yml
+++ b/.github/workflows/release-alexa-ask-skill.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-aqua-enterprise-enforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-enforcer.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-aqua-enterprise-scanner.yml
+++ b/.github/workflows/release-aqua-enterprise-scanner.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-aqua-enterprise-server.yml
+++ b/.github/workflows/release-aqua-enterprise-server.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-atlassian-opsgenie-integration.yml
+++ b/.github/workflows/release-atlassian-opsgenie-integration.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-atlassian-opsgenie-team.yml
+++ b/.github/workflows/release-atlassian-opsgenie-team.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-atlassian-opsgenie-user.yml
+++ b/.github/workflows/release-atlassian-opsgenie-user.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-account-alternatecontact.yml
+++ b/.github/workflows/release-awscommunity-account-alternatecontact.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
+++ b/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
+++ b/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-dynamodb-item.yml
+++ b/.github/workflows/release-awscommunity-dynamodb-item.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-resource-lookup.yml
+++ b/.github/workflows/release-awscommunity-resource-lookup.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-s3-bucket-module.yml
+++ b/.github/workflows/release-awscommunity-s3-bucket-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
+++ b/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-time-offset.yml
+++ b/.github/workflows/release-awscommunity-time-offset.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-time-sleep.yml
+++ b/.github/workflows/release-awscommunity-time-sleep.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awscommunity-time-static.yml
+++ b/.github/workflows/release-awscommunity-time-static.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
+++ b/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
+++ b/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-eks-cluster.yml
+++ b/.github/workflows/release-awsqs-eks-cluster.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
+++ b/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-kubernetes-get.yml
+++ b/.github/workflows/release-awsqs-kubernetes-get.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-kubernetes-helm.yml
+++ b/.github/workflows/release-awsqs-kubernetes-helm.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-kubernetes-resource.yml
+++ b/.github/workflows/release-awsqs-kubernetes-resource.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
+++ b/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-bigid-datasource-dynamodb.yml
+++ b/.github/workflows/release-bigid-datasource-dynamodb.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-bigid-datasource-s3.yml
+++ b/.github/workflows/release-bigid-datasource-s3.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-cadiaz-bucket-uno-module.yml
+++ b/.github/workflows/release-cadiaz-bucket-uno-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-cloudflare-dns-record.yml
+++ b/.github/workflows/release-cloudflare-dns-record.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-cloudflare-loadbalancer-pool.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-pool.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
+++ b/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-cyral-sidecar-deployment-module.yml
+++ b/.github/workflows/release-cyral-sidecar-deployment-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-databricks-clusters-cluster.yml
+++ b/.github/workflows/release-databricks-clusters-cluster.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-databricks-clusters-job.yml
+++ b/.github/workflows/release-databricks-clusters-job.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-datadog-dashboards-dashboard.yml
+++ b/.github/workflows/release-datadog-dashboards-dashboard.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-datadog-integrations-aws.yml
+++ b/.github/workflows/release-datadog-integrations-aws.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-datadog-monitors-downtime.yml
+++ b/.github/workflows/release-datadog-monitors-downtime.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-datadog-monitors-downtimeschedule.yml
+++ b/.github/workflows/release-datadog-monitors-downtimeschedule.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-datadog-monitors-monitor.yml
+++ b/.github/workflows/release-datadog-monitors-monitor.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-datadog-slos-slo.yml
+++ b/.github/workflows/release-datadog-slos-slo.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-dynatrace-configuration-dashboard.yml
+++ b/.github/workflows/release-dynatrace-configuration-dashboard.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-dynatrace-environment-metric.yml
+++ b/.github/workflows/release-dynatrace-environment-metric.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
+++ b/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-dictionary-dictionary.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionary.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-logging-s3.yml
+++ b/.github/workflows/release-fastly-logging-s3.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-logging-splunk.yml
+++ b/.github/workflows/release-fastly-logging-splunk.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-services-activeversion.yml
+++ b/.github/workflows/release-fastly-services-activeversion.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-services-backend.yml
+++ b/.github/workflows/release-fastly-services-backend.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-services-domain.yml
+++ b/.github/workflows/release-fastly-services-domain.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-services-healthcheck.yml
+++ b/.github/workflows/release-fastly-services-healthcheck.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-services-service.yml
+++ b/.github/workflows/release-fastly-services-service.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-services-version.yml
+++ b/.github/workflows/release-fastly-services-version.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-tls-certificate.yml
+++ b/.github/workflows/release-fastly-tls-certificate.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-tls-domain.yml
+++ b/.github/workflows/release-fastly-tls-domain.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fastly-tls-privatekeys.yml
+++ b/.github/workflows/release-fastly-tls-privatekeys.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
+++ b/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-spider-cloudfront-module.yml
+++ b/.github/workflows/release-freyraim-spider-cloudfront-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-spider-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-spider-ec2instance-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-spider-ecs-module.yml
+++ b/.github/workflows/release-freyraim-spider-ecs-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-spider-postgresql-module.yml
+++ b/.github/workflows/release-freyraim-spider-postgresql-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-freyraim-spider-s3bucket-module.yml
+++ b/.github/workflows/release-freyraim-spider-s3bucket-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-generic-database-schema.yml
+++ b/.github/workflows/release-generic-database-schema.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-generic-transcribe-vocabulary.yml
+++ b/.github/workflows/release-generic-transcribe-vocabulary.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-git-tag.yml
+++ b/.github/workflows/release-github-git-tag.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-organizations-membership.yml
+++ b/.github/workflows/release-github-organizations-membership.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-organizations-secret.yml
+++ b/.github/workflows/release-github-organizations-secret.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-repositories-collaborator.yml
+++ b/.github/workflows/release-github-repositories-collaborator.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-repositories-repository.yml
+++ b/.github/workflows/release-github-repositories-repository.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-repositories-secret.yml
+++ b/.github/workflows/release-github-repositories-secret.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-repositories-webhook.yml
+++ b/.github/workflows/release-github-repositories-webhook.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-teams-membership.yml
+++ b/.github/workflows/release-github-teams-membership.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-teams-repositoryaccess.yml
+++ b/.github/workflows/release-github-teams-repositoryaccess.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-github-teams-team.yml
+++ b/.github/workflows/release-github-teams-team.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-code-tag.yml
+++ b/.github/workflows/release-gitlab-code-tag.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-groups-group.yml
+++ b/.github/workflows/release-gitlab-groups-group.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
+++ b/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
+++ b/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-projects-accesstoken.yml
+++ b/.github/workflows/release-gitlab-projects-accesstoken.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
+++ b/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-projects-project.yml
+++ b/.github/workflows/release-gitlab-projects-project.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gitlab-projects-usermemberofproject.yml
+++ b/.github/workflows/release-gitlab-projects-usermemberofproject.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-gremlin-agent-helm.yml
+++ b/.github/workflows/release-gremlin-agent-helm.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-artifactory-core-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-core-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-linux-bastion-module.yml
+++ b/.github/workflows/release-jfrog-linux-bastion-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-vpc-multiaz-module.yml
+++ b/.github/workflows/release-jfrog-vpc-multiaz-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-jfrog-xray-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-xray-ec2instance-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-karte-eventbridge-documentdb-module.yml
+++ b/.github/workflows/release-karte-eventbridge-documentdb-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
+++ b/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-logzio-awscostandusage-cur-module.yml
+++ b/.github/workflows/release-logzio-awscostandusage-cur-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
+++ b/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
+++ b/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-logzio-myservice-myname-module.yml
+++ b/.github/workflows/release-logzio-myservice-myname-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-mavi-pipeline-default-module.yml
+++ b/.github/workflows/release-mavi-pipeline-default-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-mongodb-atlas-cluster.yml
+++ b/.github/workflows/release-mongodb-atlas-cluster.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-mongodb-atlas-databaseuser.yml
+++ b/.github/workflows/release-mongodb-atlas-databaseuser.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-mongodb-atlas-networkpeering.yml
+++ b/.github/workflows/release-mongodb-atlas-networkpeering.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-mongodb-atlas-project.yml
+++ b/.github/workflows/release-mongodb-atlas-project.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
+++ b/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-agent-configuration.yml
+++ b/.github/workflows/release-newrelic-agent-configuration.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-alert-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-alert-alertspolicy.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
+++ b/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-cloudformation-dashboards.yml
+++ b/.github/workflows/release-newrelic-cloudformation-dashboards.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-cloudformation-tagging.yml
+++ b/.github/workflows/release-newrelic-cloudformation-tagging.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-cloudformation-workloads.yml
+++ b/.github/workflows/release-newrelic-cloudformation-workloads.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-aiworkflows.yml
+++ b/.github/workflows/release-newrelic-observability-aiworkflows.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
+++ b/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
+++ b/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-observability-alertspolicy.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-dashboards.yml
+++ b/.github/workflows/release-newrelic-observability-dashboards.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-newrelic-observability-workloads.yml
+++ b/.github/workflows/release-newrelic-observability-workloads.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-okta-application-application.yml
+++ b/.github/workflows/release-okta-application-application.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-okta-group-group.yml
+++ b/.github/workflows/release-okta-group-group.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-okta-group-groupapplicationassociation.yml
+++ b/.github/workflows/release-okta-group-groupapplicationassociation.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-okta-group-membership.yml
+++ b/.github/workflows/release-okta-group-membership.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-okta-policy-policy.yml
+++ b/.github/workflows/release-okta-policy-policy.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-org-test-sample-module.yml
+++ b/.github/workflows/release-org-test-sample-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
+++ b/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-pagerduty-responseplays-responseplay.yml
+++ b/.github/workflows/release-pagerduty-responseplays-responseplay.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-pagerduty-schedules-schedule.yml
+++ b/.github/workflows/release-pagerduty-schedules-schedule.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-pagerduty-teams-membership.yml
+++ b/.github/workflows/release-pagerduty-teams-membership.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-pagerduty-teams-team.yml
+++ b/.github/workflows/release-pagerduty-teams-team.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-pagerduty-users-user.yml
+++ b/.github/workflows/release-pagerduty-users-user.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-poc-azure-blobstorage.yml
+++ b/.github/workflows/release-poc-azure-blobstorage.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-registry-test-resource1-module.yml
+++ b/.github/workflows/release-registry-test-resource1-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-rollbar-notifications-rule.yml
+++ b/.github/workflows/release-rollbar-notifications-rule.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-rollbar-projects-accesstoken.yml
+++ b/.github/workflows/release-rollbar-projects-accesstoken.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-rollbar-projects-project.yml
+++ b/.github/workflows/release-rollbar-projects-project.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-rollbar-teams-membership.yml
+++ b/.github/workflows/release-rollbar-teams-membership.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-rollbar-teams-team.yml
+++ b/.github/workflows/release-rollbar-teams-team.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snowflake-database-database.yml
+++ b/.github/workflows/release-snowflake-database-database.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snowflake-database-grant.yml
+++ b/.github/workflows/release-snowflake-database-grant.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snowflake-role-grant.yml
+++ b/.github/workflows/release-snowflake-role-grant.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snowflake-role-role.yml
+++ b/.github/workflows/release-snowflake-role-role.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snowflake-user-user.yml
+++ b/.github/workflows/release-snowflake-user-user.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snowflake-warehouse-grant.yml
+++ b/.github/workflows/release-snowflake-warehouse-grant.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-snyk-container-helm.yml
+++ b/.github/workflows/release-snyk-container-helm.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-splunk-enterprise-quickstart-module.yml
+++ b/.github/workflows/release-splunk-enterprise-quickstart-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-spot-elastigroup-group.yml
+++ b/.github/workflows/release-spot-elastigroup-group.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-stackery-open-bastion-module.yml
+++ b/.github/workflows/release-stackery-open-bastion-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-stocks-orders-marketorder.yml
+++ b/.github/workflows/release-stocks-orders-marketorder.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
+++ b/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-sysdig-helm-agent.yml
+++ b/.github/workflows/release-sysdig-helm-agent.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-ad-computer.yml
+++ b/.github/workflows/release-tf-ad-computer.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-ad-user.yml
+++ b/.github/workflows/release-tf-ad-user.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-aws-keypair.yml
+++ b/.github/workflows/release-tf-aws-keypair.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-aws-s3bucket.yml
+++ b/.github/workflows/release-tf-aws-s3bucket.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-aws-s3bucketobject.yml
+++ b/.github/workflows/release-tf-aws-s3bucketobject.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-azuread-application.yml
+++ b/.github/workflows/release-tf-azuread-application.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-azuread-user.yml
+++ b/.github/workflows/release-tf-azuread-user.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-cloudflare-record.yml
+++ b/.github/workflows/release-tf-cloudflare-record.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-digitalocean-droplet.yml
+++ b/.github/workflows/release-tf-digitalocean-droplet.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-github-repository.yml
+++ b/.github/workflows/release-tf-github-repository.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-google-storagebucket.yml
+++ b/.github/workflows/release-tf-google-storagebucket.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-pagerduty-service.yml
+++ b/.github/workflows/release-tf-pagerduty-service.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-random-string.yml
+++ b/.github/workflows/release-tf-random-string.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-tf-random-uuid.yml
+++ b/.github/workflows/release-tf-random-uuid.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
+++ b/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-unxpose-iam-integration-module.yml
+++ b/.github/workflows/release-unxpose-iam-integration-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
+++ b/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set git identity
         run: |-
           git config user.name "github-actions"

--- a/projenrc/type-package.ts
+++ b/projenrc/type-package.ts
@@ -277,6 +277,9 @@ export class CloudFormationTypeProject extends Component {
         {
           name: 'Checkout',
           uses: 'actions/checkout@v4',
+          with: {
+            'fetch-depth': 0,
+          },
         },
 
         // sets git identity so we can push later


### PR DESCRIPTION
If we have only one commit available locally, we cannot determine if pervious tags/commits have been released already. Duh.
