### PR TITLE
chore: fix cannot use different versions of upload-artifact and download-artifact together

### DIFF
--- a/.github/workflows/release-alexa-ask-skill.yml
+++ b/.github/workflows/release-alexa-ask-skill.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/alexa-ask-skill/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-aqua-enterprise-enforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-enforcer.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/aqua-enterprise-enforcer/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/aqua-enterprise-kubeenforcer/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-aqua-enterprise-scanner.yml
+++ b/.github/workflows/release-aqua-enterprise-scanner.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/aqua-enterprise-scanner/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-aqua-enterprise-server.yml
+++ b/.github/workflows/release-aqua-enterprise-server.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/aqua-enterprise-server/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-atlassian-opsgenie-integration.yml
+++ b/.github/workflows/release-atlassian-opsgenie-integration.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/atlassian-opsgenie-integration/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-atlassian-opsgenie-team.yml
+++ b/.github/workflows/release-atlassian-opsgenie-team.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/atlassian-opsgenie-team/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-atlassian-opsgenie-user.yml
+++ b/.github/workflows/release-atlassian-opsgenie-user.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/atlassian-opsgenie-user/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-account-alternatecontact.yml
+++ b/.github/workflows/release-awscommunity-account-alternatecontact.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-account-alternatecontact/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
+++ b/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-applicationautoscaling-scheduledaction/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
+++ b/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-cloudfront-s3website-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-dynamodb-item.yml
+++ b/.github/workflows/release-awscommunity-dynamodb-item.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-dynamodb-item/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-resource-lookup.yml
+++ b/.github/workflows/release-awscommunity-resource-lookup.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-resource-lookup/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-s3-bucket-module.yml
+++ b/.github/workflows/release-awscommunity-s3-bucket-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-s3-bucket-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
+++ b/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-s3-deletebucketcontents/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-time-offset.yml
+++ b/.github/workflows/release-awscommunity-time-offset.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-time-offset/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-time-sleep.yml
+++ b/.github/workflows/release-awscommunity-time-sleep.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-time-sleep/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awscommunity-time-static.yml
+++ b/.github/workflows/release-awscommunity-time-static.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awscommunity-time-static/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
+++ b/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-checkpoint-cloudguardqs-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
+++ b/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-ec2-linuxbastionqs-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-eks-cluster.yml
+++ b/.github/workflows/release-awsqs-eks-cluster.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-eks-cluster/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
+++ b/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-iridium-cloudconnectqs-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-kubernetes-get.yml
+++ b/.github/workflows/release-awsqs-kubernetes-get.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-kubernetes-get/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-kubernetes-helm.yml
+++ b/.github/workflows/release-awsqs-kubernetes-helm.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-kubernetes-helm/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-kubernetes-resource.yml
+++ b/.github/workflows/release-awsqs-kubernetes-resource.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-kubernetes-resource/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
+++ b/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/awsqs-vpc-vpcqs-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-bigid-datasource-dynamodb.yml
+++ b/.github/workflows/release-bigid-datasource-dynamodb.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/bigid-datasource-dynamodb/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-bigid-datasource-s3.yml
+++ b/.github/workflows/release-bigid-datasource-s3.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/bigid-datasource-s3/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-cadiaz-bucket-uno-module.yml
+++ b/.github/workflows/release-cadiaz-bucket-uno-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/cadiaz-bucket-uno-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-cloudflare-dns-record.yml
+++ b/.github/workflows/release-cloudflare-dns-record.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/cloudflare-dns-record/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/cloudflare-loadbalancer-loadbalancer/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/cloudflare-loadbalancer-monitor/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-cloudflare-loadbalancer-pool.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-pool.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/cloudflare-loadbalancer-pool/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
+++ b/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/confluentcloud-iam-serviceaccount/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-cyral-sidecar-deployment-module.yml
+++ b/.github/workflows/release-cyral-sidecar-deployment-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/cyral-sidecar-deployment-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-databricks-clusters-cluster.yml
+++ b/.github/workflows/release-databricks-clusters-cluster.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/databricks-clusters-cluster/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-databricks-clusters-job.yml
+++ b/.github/workflows/release-databricks-clusters-job.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/databricks-clusters-job/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-datadog-dashboards-dashboard.yml
+++ b/.github/workflows/release-datadog-dashboards-dashboard.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/datadog-dashboards-dashboard/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-datadog-integrations-aws.yml
+++ b/.github/workflows/release-datadog-integrations-aws.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/datadog-integrations-aws/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-datadog-monitors-downtime.yml
+++ b/.github/workflows/release-datadog-monitors-downtime.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/datadog-monitors-downtime/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-datadog-monitors-downtimeschedule.yml
+++ b/.github/workflows/release-datadog-monitors-downtimeschedule.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/datadog-monitors-downtimeschedule/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-datadog-monitors-monitor.yml
+++ b/.github/workflows/release-datadog-monitors-monitor.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/datadog-monitors-monitor/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-datadog-slos-slo.yml
+++ b/.github/workflows/release-datadog-slos-slo.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/datadog-slos-slo/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-dynatrace-configuration-dashboard.yml
+++ b/.github/workflows/release-dynatrace-configuration-dashboard.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/dynatrace-configuration-dashboard/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-dynatrace-environment-metric.yml
+++ b/.github/workflows/release-dynatrace-environment-metric.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/dynatrace-environment-metric/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
+++ b/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/dynatrace-environment-servicelevelobjective/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/dynatrace-environment-syntheticlocation/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/dynatrace-environment-syntheticmonitor/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-dictionary-dictionary.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionary.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-dictionary-dictionary/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-dictionary-dictionaryitem/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-logging-s3.yml
+++ b/.github/workflows/release-fastly-logging-s3.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-logging-s3/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-logging-splunk.yml
+++ b/.github/workflows/release-fastly-logging-splunk.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-logging-splunk/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-services-activeversion.yml
+++ b/.github/workflows/release-fastly-services-activeversion.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-services-activeversion/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-services-backend.yml
+++ b/.github/workflows/release-fastly-services-backend.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-services-backend/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-services-domain.yml
+++ b/.github/workflows/release-fastly-services-domain.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-services-domain/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-services-healthcheck.yml
+++ b/.github/workflows/release-fastly-services-healthcheck.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-services-healthcheck/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-services-service.yml
+++ b/.github/workflows/release-fastly-services-service.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-services-service/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-services-version.yml
+++ b/.github/workflows/release-fastly-services-version.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-services-version/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-tls-certificate.yml
+++ b/.github/workflows/release-fastly-tls-certificate.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-tls-certificate/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-tls-domain.yml
+++ b/.github/workflows/release-fastly-tls-domain.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-tls-domain/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fastly-tls-privatekeys.yml
+++ b/.github/workflows/release-fastly-tls-privatekeys.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fastly-tls-privatekeys/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
+++ b/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/fireeye-cloudintegrations-cloudwatch/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-impactapi-apigateway-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-impactapi-apihandle-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-impactapi-ec2instance-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-impactapi-lambdafunction-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-impactapi-loadbalancer-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-spider-cloudfront-module.yml
+++ b/.github/workflows/release-freyraim-spider-cloudfront-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-spider-cloudfront-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-spider-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-spider-ec2instance-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-spider-ec2instance-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-spider-ecs-module.yml
+++ b/.github/workflows/release-freyraim-spider-ecs-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-spider-ecs-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-spider-loadbalancer-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-spider-postgresql-module.yml
+++ b/.github/workflows/release-freyraim-spider-postgresql-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-spider-postgresql-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-freyraim-spider-s3bucket-module.yml
+++ b/.github/workflows/release-freyraim-spider-s3bucket-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/freyraim-spider-s3bucket-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-generic-database-schema.yml
+++ b/.github/workflows/release-generic-database-schema.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/generic-database-schema/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-generic-transcribe-vocabulary.yml
+++ b/.github/workflows/release-generic-transcribe-vocabulary.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/generic-transcribe-vocabulary/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-git-tag.yml
+++ b/.github/workflows/release-github-git-tag.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-git-tag/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-organizations-membership.yml
+++ b/.github/workflows/release-github-organizations-membership.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-organizations-membership/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-organizations-secret.yml
+++ b/.github/workflows/release-github-organizations-secret.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-organizations-secret/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-repositories-collaborator.yml
+++ b/.github/workflows/release-github-repositories-collaborator.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-repositories-collaborator/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-repositories-repository.yml
+++ b/.github/workflows/release-github-repositories-repository.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-repositories-repository/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-repositories-secret.yml
+++ b/.github/workflows/release-github-repositories-secret.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-repositories-secret/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-repositories-webhook.yml
+++ b/.github/workflows/release-github-repositories-webhook.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-repositories-webhook/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-teams-membership.yml
+++ b/.github/workflows/release-github-teams-membership.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-teams-membership/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-teams-repositoryaccess.yml
+++ b/.github/workflows/release-github-teams-repositoryaccess.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-teams-repositoryaccess/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-github-teams-team.yml
+++ b/.github/workflows/release-github-teams-team.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/github-teams-team/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-code-tag.yml
+++ b/.github/workflows/release-gitlab-code-tag.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-code-tag/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-groups-group.yml
+++ b/.github/workflows/release-gitlab-groups-group.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-groups-group/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
+++ b/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-groups-groupaccesstogroup/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
+++ b/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-groups-usermemberofgroup/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-projects-accesstoken.yml
+++ b/.github/workflows/release-gitlab-projects-accesstoken.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-projects-accesstoken/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
+++ b/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-projects-groupaccesstoproject/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-projects-project.yml
+++ b/.github/workflows/release-gitlab-projects-project.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-projects-project/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gitlab-projects-usermemberofproject.yml
+++ b/.github/workflows/release-gitlab-projects-usermemberofproject.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gitlab-projects-usermemberofproject/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-gremlin-agent-helm.yml
+++ b/.github/workflows/release-gremlin-agent-helm.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/gremlin-agent-helm/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-artifactory-core-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-core-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-artifactory-core-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-artifactory-ec2instance-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-artifactory-existingvpc-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-artifactory-newvpc-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-linux-bastion-module.yml
+++ b/.github/workflows/release-jfrog-linux-bastion-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-linux-bastion-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-vpc-multiaz-module.yml
+++ b/.github/workflows/release-jfrog-vpc-multiaz-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-vpc-multiaz-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-jfrog-xray-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-xray-ec2instance-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/jfrog-xray-ec2instance-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-karte-eventbridge-documentdb-module.yml
+++ b/.github/workflows/release-karte-eventbridge-documentdb-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/karte-eventbridge-documentdb-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
+++ b/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/logzio-autodeploymentlogzio-cloudwatch-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-logzio-awscostandusage-cur-module.yml
+++ b/.github/workflows/release-logzio-awscostandusage-cur-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/logzio-awscostandusage-cur-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
+++ b/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/logzio-awssecurityhub-collector-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
+++ b/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/logzio-kinesisshipper-kinesisshipper-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-logzio-myservice-myname-module.yml
+++ b/.github/workflows/release-logzio-myservice-myname-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/logzio-myservice-myname-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-mavi-pipeline-default-module.yml
+++ b/.github/workflows/release-mavi-pipeline-default-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/mavi-pipeline-default-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-mongodb-atlas-cluster.yml
+++ b/.github/workflows/release-mongodb-atlas-cluster.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/mongodb-atlas-cluster/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-mongodb-atlas-databaseuser.yml
+++ b/.github/workflows/release-mongodb-atlas-databaseuser.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/mongodb-atlas-databaseuser/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-mongodb-atlas-networkpeering.yml
+++ b/.github/workflows/release-mongodb-atlas-networkpeering.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/mongodb-atlas-networkpeering/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-mongodb-atlas-project.yml
+++ b/.github/workflows/release-mongodb-atlas-project.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/mongodb-atlas-project/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
+++ b/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/mongodb-atlas-projectipaccesslist/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-agent-configuration.yml
+++ b/.github/workflows/release-newrelic-agent-configuration.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-agent-configuration/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-alert-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-alert-alertspolicy.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-alert-alertspolicy/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
+++ b/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-alert-nrqlconditionstatic/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-cloudformation-dashboards.yml
+++ b/.github/workflows/release-newrelic-cloudformation-dashboards.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-cloudformation-dashboards/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-cloudformation-tagging.yml
+++ b/.github/workflows/release-newrelic-cloudformation-tagging.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-cloudformation-tagging/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-cloudformation-workloads.yml
+++ b/.github/workflows/release-newrelic-cloudformation-workloads.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-cloudformation-workloads/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-ainotificationschannel/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-ainotificationsdestination/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-aiworkflows.yml
+++ b/.github/workflows/release-newrelic-observability-aiworkflows.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-aiworkflows/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
+++ b/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-alertsmutingrule/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
+++ b/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-alertsnrqlcondition/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-observability-alertspolicy.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-alertspolicy/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-dashboards.yml
+++ b/.github/workflows/release-newrelic-observability-dashboards.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-dashboards/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-newrelic-observability-workloads.yml
+++ b/.github/workflows/release-newrelic-observability-workloads.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/newrelic-observability-workloads/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-okta-application-application.yml
+++ b/.github/workflows/release-okta-application-application.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/okta-application-application/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-okta-group-group.yml
+++ b/.github/workflows/release-okta-group-group.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/okta-group-group/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-okta-group-groupapplicationassociation.yml
+++ b/.github/workflows/release-okta-group-groupapplicationassociation.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/okta-group-groupapplicationassociation/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-okta-group-membership.yml
+++ b/.github/workflows/release-okta-group-membership.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/okta-group-membership/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-okta-policy-policy.yml
+++ b/.github/workflows/release-okta-policy-policy.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/okta-policy-policy/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-org-test-sample-module.yml
+++ b/.github/workflows/release-org-test-sample-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/org-test-sample-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
+++ b/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/pagerduty-escalationpolicies-escalationpolicy/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-pagerduty-responseplays-responseplay.yml
+++ b/.github/workflows/release-pagerduty-responseplays-responseplay.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/pagerduty-responseplays-responseplay/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-pagerduty-schedules-schedule.yml
+++ b/.github/workflows/release-pagerduty-schedules-schedule.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/pagerduty-schedules-schedule/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-pagerduty-teams-membership.yml
+++ b/.github/workflows/release-pagerduty-teams-membership.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/pagerduty-teams-membership/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-pagerduty-teams-team.yml
+++ b/.github/workflows/release-pagerduty-teams-team.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/pagerduty-teams-team/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-pagerduty-users-user.yml
+++ b/.github/workflows/release-pagerduty-users-user.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/pagerduty-users-user/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-ngfw/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/paloaltonetworks-cloudngfw-rulestack/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-poc-azure-blobstorage.yml
+++ b/.github/workflows/release-poc-azure-blobstorage.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/poc-azure-blobstorage/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-registry-test-resource1-module.yml
+++ b/.github/workflows/release-registry-test-resource1-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/registry-test-resource1-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-rollbar-notifications-rule.yml
+++ b/.github/workflows/release-rollbar-notifications-rule.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/rollbar-notifications-rule/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-rollbar-projects-accesstoken.yml
+++ b/.github/workflows/release-rollbar-projects-accesstoken.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/rollbar-projects-accesstoken/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-rollbar-projects-project.yml
+++ b/.github/workflows/release-rollbar-projects-project.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/rollbar-projects-project/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-rollbar-teams-membership.yml
+++ b/.github/workflows/release-rollbar-teams-membership.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/rollbar-teams-membership/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-rollbar-teams-team.yml
+++ b/.github/workflows/release-rollbar-teams-team.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/rollbar-teams-team/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snowflake-database-database.yml
+++ b/.github/workflows/release-snowflake-database-database.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snowflake-database-database/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snowflake-database-grant.yml
+++ b/.github/workflows/release-snowflake-database-grant.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snowflake-database-grant/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snowflake-role-grant.yml
+++ b/.github/workflows/release-snowflake-role-grant.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snowflake-role-grant/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snowflake-role-role.yml
+++ b/.github/workflows/release-snowflake-role-role.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snowflake-role-role/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snowflake-user-user.yml
+++ b/.github/workflows/release-snowflake-user-user.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snowflake-user-user/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snowflake-warehouse-grant.yml
+++ b/.github/workflows/release-snowflake-warehouse-grant.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snowflake-warehouse-grant/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-snyk-container-helm.yml
+++ b/.github/workflows/release-snyk-container-helm.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/snyk-container-helm/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-splunk-enterprise-quickstart-module.yml
+++ b/.github/workflows/release-splunk-enterprise-quickstart-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/splunk-enterprise-quickstart-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-spot-elastigroup-group.yml
+++ b/.github/workflows/release-spot-elastigroup-group.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/spot-elastigroup-group/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-stackery-open-bastion-module.yml
+++ b/.github/workflows/release-stackery-open-bastion-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/stackery-open-bastion-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-stocks-orders-marketorder.yml
+++ b/.github/workflows/release-stocks-orders-marketorder.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/stocks-orders-marketorder/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
+++ b/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/symphonia-opensource-cloudformationartifactsbucket-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-sysdig-helm-agent.yml
+++ b/.github/workflows/release-sysdig-helm-agent.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/sysdig-helm-agent/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-ad-computer.yml
+++ b/.github/workflows/release-tf-ad-computer.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-ad-computer/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-ad-user.yml
+++ b/.github/workflows/release-tf-ad-user.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-ad-user/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-aws-keypair.yml
+++ b/.github/workflows/release-tf-aws-keypair.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-aws-keypair/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-aws-s3bucket.yml
+++ b/.github/workflows/release-tf-aws-s3bucket.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-aws-s3bucket/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-aws-s3bucketobject.yml
+++ b/.github/workflows/release-tf-aws-s3bucketobject.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-aws-s3bucketobject/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-azuread-application.yml
+++ b/.github/workflows/release-tf-azuread-application.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-azuread-application/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-azuread-user.yml
+++ b/.github/workflows/release-tf-azuread-user.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-azuread-user/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-cloudflare-record.yml
+++ b/.github/workflows/release-tf-cloudflare-record.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-cloudflare-record/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-digitalocean-droplet.yml
+++ b/.github/workflows/release-tf-digitalocean-droplet.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-digitalocean-droplet/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-github-repository.yml
+++ b/.github/workflows/release-tf-github-repository.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-github-repository/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-google-storagebucket.yml
+++ b/.github/workflows/release-tf-google-storagebucket.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-google-storagebucket/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-pagerduty-service.yml
+++ b/.github/workflows/release-tf-pagerduty-service.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-pagerduty-service/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-random-string.yml
+++ b/.github/workflows/release-tf-random-string.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-random-string/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-tf-random-uuid.yml
+++ b/.github/workflows/release-tf-random-uuid.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/tf-random-uuid/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
+++ b/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/trendmicro-cloudonecontainer-helm/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-unxpose-iam-integration-module.yml
+++ b/.github/workflows/release-unxpose-iam-integration-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/unxpose-iam-integration-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
+++ b/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
@@ -53,7 +53,7 @@ jobs:
         run: mv packages/@cdk-cloudformation/zmk-iam-lambdabasicrole-module/dist .
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: build-artifact
           path: dist

--- a/projenrc/type-package.ts
+++ b/projenrc/type-package.ts
@@ -324,7 +324,7 @@ export class CloudFormationTypeProject extends Component {
         },
         {
           name: 'Upload artifact',
-          uses: 'actions/upload-artifact@v4',
+          uses: 'actions/upload-artifact@v3',
           // Always upload files even if previous steps have failed; for debugging
           if: 'always()',
           with: {


### PR DESCRIPTION
I changed actions/upload-artifact to v4 because I could. However the download-artifact step is coming form upstream and cannot be changed easily. Turns our you cannot mix these two versions.