### PR TITLE
chore: switch to superchain Node 20

### DIFF
--- a/.github/workflows/build-individual.yml
+++ b/.github/workflows/build-individual.yml
@@ -205,7 +205,7 @@ jobs:
           - unxpose-iam-integration-module
           - zmk-iam-lambdabasicrole-module
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   build-okay:
     name: Build Individual
     needs: build-all

--- a/.github/workflows/release-alexa-ask-skill.yml
+++ b/.github/workflows/release-alexa-ask-skill.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-aqua-enterprise-enforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-enforcer.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
+++ b/.github/workflows/release-aqua-enterprise-kubeenforcer.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-aqua-enterprise-scanner.yml
+++ b/.github/workflows/release-aqua-enterprise-scanner.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-aqua-enterprise-server.yml
+++ b/.github/workflows/release-aqua-enterprise-server.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-atlassian-opsgenie-integration.yml
+++ b/.github/workflows/release-atlassian-opsgenie-integration.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-atlassian-opsgenie-team.yml
+++ b/.github/workflows/release-atlassian-opsgenie-team.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-atlassian-opsgenie-user.yml
+++ b/.github/workflows/release-atlassian-opsgenie-user.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-account-alternatecontact.yml
+++ b/.github/workflows/release-awscommunity-account-alternatecontact.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
+++ b/.github/workflows/release-awscommunity-applicationautoscaling-scheduledaction.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
+++ b/.github/workflows/release-awscommunity-cloudfront-s3website-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-dynamodb-item.yml
+++ b/.github/workflows/release-awscommunity-dynamodb-item.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-resource-lookup.yml
+++ b/.github/workflows/release-awscommunity-resource-lookup.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-s3-bucket-module.yml
+++ b/.github/workflows/release-awscommunity-s3-bucket-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
+++ b/.github/workflows/release-awscommunity-s3-deletebucketcontents.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-time-offset.yml
+++ b/.github/workflows/release-awscommunity-time-offset.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-time-sleep.yml
+++ b/.github/workflows/release-awscommunity-time-sleep.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awscommunity-time-static.yml
+++ b/.github/workflows/release-awscommunity-time-static.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
+++ b/.github/workflows/release-awsqs-checkpoint-cloudguardqs-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
+++ b/.github/workflows/release-awsqs-ec2-linuxbastionqs-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-eks-cluster.yml
+++ b/.github/workflows/release-awsqs-eks-cluster.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
+++ b/.github/workflows/release-awsqs-iridium-cloudconnectqs-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-kubernetes-get.yml
+++ b/.github/workflows/release-awsqs-kubernetes-get.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-kubernetes-helm.yml
+++ b/.github/workflows/release-awsqs-kubernetes-helm.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-kubernetes-resource.yml
+++ b/.github/workflows/release-awsqs-kubernetes-resource.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
+++ b/.github/workflows/release-awsqs-vpc-vpcqs-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-bigid-datasource-dynamodb.yml
+++ b/.github/workflows/release-bigid-datasource-dynamodb.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-bigid-datasource-s3.yml
+++ b/.github/workflows/release-bigid-datasource-s3.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-cadiaz-bucket-uno-module.yml
+++ b/.github/workflows/release-cadiaz-bucket-uno-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-cloudflare-dns-record.yml
+++ b/.github/workflows/release-cloudflare-dns-record.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-loadbalancer.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-monitor.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-cloudflare-loadbalancer-pool.yml
+++ b/.github/workflows/release-cloudflare-loadbalancer-pool.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
+++ b/.github/workflows/release-confluentcloud-iam-serviceaccount.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-cyral-sidecar-deployment-module.yml
+++ b/.github/workflows/release-cyral-sidecar-deployment-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-databricks-clusters-cluster.yml
+++ b/.github/workflows/release-databricks-clusters-cluster.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-databricks-clusters-job.yml
+++ b/.github/workflows/release-databricks-clusters-job.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-datadog-dashboards-dashboard.yml
+++ b/.github/workflows/release-datadog-dashboards-dashboard.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-datadog-integrations-aws.yml
+++ b/.github/workflows/release-datadog-integrations-aws.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-datadog-monitors-downtime.yml
+++ b/.github/workflows/release-datadog-monitors-downtime.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-datadog-monitors-downtimeschedule.yml
+++ b/.github/workflows/release-datadog-monitors-downtimeschedule.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-datadog-monitors-monitor.yml
+++ b/.github/workflows/release-datadog-monitors-monitor.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-datadog-slos-slo.yml
+++ b/.github/workflows/release-datadog-slos-slo.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-dynatrace-configuration-dashboard.yml
+++ b/.github/workflows/release-dynatrace-configuration-dashboard.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-dynatrace-environment-metric.yml
+++ b/.github/workflows/release-dynatrace-environment-metric.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
+++ b/.github/workflows/release-dynatrace-environment-servicelevelobjective.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticlocation.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
+++ b/.github/workflows/release-dynatrace-environment-syntheticmonitor.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-dictionary-dictionary.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionary.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
+++ b/.github/workflows/release-fastly-dictionary-dictionaryitem.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-logging-s3.yml
+++ b/.github/workflows/release-fastly-logging-s3.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-logging-splunk.yml
+++ b/.github/workflows/release-fastly-logging-splunk.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-services-activeversion.yml
+++ b/.github/workflows/release-fastly-services-activeversion.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-services-backend.yml
+++ b/.github/workflows/release-fastly-services-backend.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-services-domain.yml
+++ b/.github/workflows/release-fastly-services-domain.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-services-healthcheck.yml
+++ b/.github/workflows/release-fastly-services-healthcheck.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-services-service.yml
+++ b/.github/workflows/release-fastly-services-service.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-services-version.yml
+++ b/.github/workflows/release-fastly-services-version.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-tls-certificate.yml
+++ b/.github/workflows/release-fastly-tls-certificate.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-tls-domain.yml
+++ b/.github/workflows/release-fastly-tls-domain.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fastly-tls-privatekeys.yml
+++ b/.github/workflows/release-fastly-tls-privatekeys.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
+++ b/.github/workflows/release-fireeye-cloudintegrations-cloudwatch.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apigateway-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-apihandle-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-ec2instance-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-lambdafunction-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-impactapi-loadbalancer-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-spider-cloudfront-module.yml
+++ b/.github/workflows/release-freyraim-spider-cloudfront-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-spider-ec2instance-module.yml
+++ b/.github/workflows/release-freyraim-spider-ec2instance-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-spider-ecs-module.yml
+++ b/.github/workflows/release-freyraim-spider-ecs-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
+++ b/.github/workflows/release-freyraim-spider-loadbalancer-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-spider-postgresql-module.yml
+++ b/.github/workflows/release-freyraim-spider-postgresql-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-freyraim-spider-s3bucket-module.yml
+++ b/.github/workflows/release-freyraim-spider-s3bucket-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-generic-database-schema.yml
+++ b/.github/workflows/release-generic-database-schema.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-generic-transcribe-vocabulary.yml
+++ b/.github/workflows/release-generic-transcribe-vocabulary.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-git-tag.yml
+++ b/.github/workflows/release-github-git-tag.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-organizations-membership.yml
+++ b/.github/workflows/release-github-organizations-membership.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-organizations-secret.yml
+++ b/.github/workflows/release-github-organizations-secret.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-repositories-collaborator.yml
+++ b/.github/workflows/release-github-repositories-collaborator.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-repositories-repository.yml
+++ b/.github/workflows/release-github-repositories-repository.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-repositories-secret.yml
+++ b/.github/workflows/release-github-repositories-secret.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-repositories-webhook.yml
+++ b/.github/workflows/release-github-repositories-webhook.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-teams-membership.yml
+++ b/.github/workflows/release-github-teams-membership.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-teams-repositoryaccess.yml
+++ b/.github/workflows/release-github-teams-repositoryaccess.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-github-teams-team.yml
+++ b/.github/workflows/release-github-teams-team.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-code-tag.yml
+++ b/.github/workflows/release-gitlab-code-tag.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-groups-group.yml
+++ b/.github/workflows/release-gitlab-groups-group.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
+++ b/.github/workflows/release-gitlab-groups-groupaccesstogroup.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
+++ b/.github/workflows/release-gitlab-groups-usermemberofgroup.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-projects-accesstoken.yml
+++ b/.github/workflows/release-gitlab-projects-accesstoken.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
+++ b/.github/workflows/release-gitlab-projects-groupaccesstoproject.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-projects-project.yml
+++ b/.github/workflows/release-gitlab-projects-project.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gitlab-projects-usermemberofproject.yml
+++ b/.github/workflows/release-gitlab-projects-usermemberofproject.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-gremlin-agent-helm.yml
+++ b/.github/workflows/release-gremlin-agent-helm.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-artifactory-core-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-core-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-ec2instance-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-existingvpc-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
+++ b/.github/workflows/release-jfrog-artifactory-newvpc-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-linux-bastion-module.yml
+++ b/.github/workflows/release-jfrog-linux-bastion-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-vpc-multiaz-module.yml
+++ b/.github/workflows/release-jfrog-vpc-multiaz-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-jfrog-xray-ec2instance-module.yml
+++ b/.github/workflows/release-jfrog-xray-ec2instance-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-karte-eventbridge-documentdb-module.yml
+++ b/.github/workflows/release-karte-eventbridge-documentdb-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
+++ b/.github/workflows/release-logzio-autodeploymentlogzio-cloudwatch-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-logzio-awscostandusage-cur-module.yml
+++ b/.github/workflows/release-logzio-awscostandusage-cur-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
+++ b/.github/workflows/release-logzio-awssecurityhub-collector-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
+++ b/.github/workflows/release-logzio-kinesisshipper-kinesisshipper-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-logzio-myservice-myname-module.yml
+++ b/.github/workflows/release-logzio-myservice-myname-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-mavi-pipeline-default-module.yml
+++ b/.github/workflows/release-mavi-pipeline-default-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-mongodb-atlas-cluster.yml
+++ b/.github/workflows/release-mongodb-atlas-cluster.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-mongodb-atlas-databaseuser.yml
+++ b/.github/workflows/release-mongodb-atlas-databaseuser.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-mongodb-atlas-networkpeering.yml
+++ b/.github/workflows/release-mongodb-atlas-networkpeering.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-mongodb-atlas-project.yml
+++ b/.github/workflows/release-mongodb-atlas-project.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
+++ b/.github/workflows/release-mongodb-atlas-projectipaccesslist.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-agent-configuration.yml
+++ b/.github/workflows/release-newrelic-agent-configuration.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-alert-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-alert-alertspolicy.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
+++ b/.github/workflows/release-newrelic-alert-nrqlconditionstatic.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-cloudformation-dashboards.yml
+++ b/.github/workflows/release-newrelic-cloudformation-dashboards.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-cloudformation-tagging.yml
+++ b/.github/workflows/release-newrelic-cloudformation-tagging.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-cloudformation-workloads.yml
+++ b/.github/workflows/release-newrelic-cloudformation-workloads.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationschannel.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
+++ b/.github/workflows/release-newrelic-observability-ainotificationsdestination.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-aiworkflows.yml
+++ b/.github/workflows/release-newrelic-observability-aiworkflows.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
+++ b/.github/workflows/release-newrelic-observability-alertsmutingrule.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
+++ b/.github/workflows/release-newrelic-observability-alertsnrqlcondition.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-alertspolicy.yml
+++ b/.github/workflows/release-newrelic-observability-alertspolicy.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-dashboards.yml
+++ b/.github/workflows/release-newrelic-observability-dashboards.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-newrelic-observability-workloads.yml
+++ b/.github/workflows/release-newrelic-observability-workloads.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-okta-application-application.yml
+++ b/.github/workflows/release-okta-application-application.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-okta-group-group.yml
+++ b/.github/workflows/release-okta-group-group.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-okta-group-groupapplicationassociation.yml
+++ b/.github/workflows/release-okta-group-groupapplicationassociation.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-okta-group-membership.yml
+++ b/.github/workflows/release-okta-group-membership.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-okta-policy-policy.yml
+++ b/.github/workflows/release-okta-policy-policy.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-org-test-sample-module.yml
+++ b/.github/workflows/release-org-test-sample-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
+++ b/.github/workflows/release-pagerduty-escalationpolicies-escalationpolicy.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-responseplays-responseplay.yml
+++ b/.github/workflows/release-pagerduty-responseplays-responseplay.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-schedules-schedule.yml
+++ b/.github/workflows/release-pagerduty-schedules-schedule.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-services-integration.yml
+++ b/.github/workflows/release-pagerduty-services-integration.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-services-service.yml
+++ b/.github/workflows/release-pagerduty-services-service.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-teams-membership.yml
+++ b/.github/workflows/release-pagerduty-teams-membership.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-teams-team.yml
+++ b/.github/workflows/release-pagerduty-teams-team.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-pagerduty-users-user.yml
+++ b/.github/workflows/release-pagerduty-users-user.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-ngfw.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
+++ b/.github/workflows/release-paloaltonetworks-cloudngfw-rulestack.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-poc-azure-blobstorage.yml
+++ b/.github/workflows/release-poc-azure-blobstorage.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-registry-test-resource1-module.yml
+++ b/.github/workflows/release-registry-test-resource1-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-rollbar-notifications-rule.yml
+++ b/.github/workflows/release-rollbar-notifications-rule.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-rollbar-projects-accesstoken.yml
+++ b/.github/workflows/release-rollbar-projects-accesstoken.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-rollbar-projects-project.yml
+++ b/.github/workflows/release-rollbar-projects-project.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-rollbar-teams-membership.yml
+++ b/.github/workflows/release-rollbar-teams-membership.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-rollbar-teams-team.yml
+++ b/.github/workflows/release-rollbar-teams-team.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snowflake-database-database.yml
+++ b/.github/workflows/release-snowflake-database-database.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snowflake-database-grant.yml
+++ b/.github/workflows/release-snowflake-database-grant.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snowflake-role-grant.yml
+++ b/.github/workflows/release-snowflake-role-grant.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snowflake-role-role.yml
+++ b/.github/workflows/release-snowflake-role-role.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snowflake-user-user.yml
+++ b/.github/workflows/release-snowflake-user-user.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snowflake-warehouse-grant.yml
+++ b/.github/workflows/release-snowflake-warehouse-grant.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-snyk-container-helm.yml
+++ b/.github/workflows/release-snyk-container-helm.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-splunk-enterprise-quickstart-module.yml
+++ b/.github/workflows/release-splunk-enterprise-quickstart-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-spot-elastigroup-group.yml
+++ b/.github/workflows/release-spot-elastigroup-group.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-stackery-open-bastion-module.yml
+++ b/.github/workflows/release-stackery-open-bastion-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-stocks-orders-marketorder.yml
+++ b/.github/workflows/release-stocks-orders-marketorder.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-svectordb-vectordatabase-apikey.yml
+++ b/.github/workflows/release-svectordb-vectordatabase-apikey.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-svectordb-vectordatabase-database.yml
+++ b/.github/workflows/release-svectordb-vectordatabase-database.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
+++ b/.github/workflows/release-symphonia-opensource-cloudformationartifactsbucket-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-sysdig-helm-agent.yml
+++ b/.github/workflows/release-sysdig-helm-agent.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-ad-computer.yml
+++ b/.github/workflows/release-tf-ad-computer.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-ad-user.yml
+++ b/.github/workflows/release-tf-ad-user.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-aws-keypair.yml
+++ b/.github/workflows/release-tf-aws-keypair.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-aws-s3bucket.yml
+++ b/.github/workflows/release-tf-aws-s3bucket.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-aws-s3bucketobject.yml
+++ b/.github/workflows/release-tf-aws-s3bucketobject.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-azuread-application.yml
+++ b/.github/workflows/release-tf-azuread-application.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-azuread-user.yml
+++ b/.github/workflows/release-tf-azuread-user.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-cloudflare-record.yml
+++ b/.github/workflows/release-tf-cloudflare-record.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-digitalocean-droplet.yml
+++ b/.github/workflows/release-tf-digitalocean-droplet.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-github-repository.yml
+++ b/.github/workflows/release-tf-github-repository.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-google-storagebucket.yml
+++ b/.github/workflows/release-tf-google-storagebucket.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-pagerduty-service.yml
+++ b/.github/workflows/release-tf-pagerduty-service.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-random-string.yml
+++ b/.github/workflows/release-tf-random-string.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-tf-random-uuid.yml
+++ b/.github/workflows/release-tf-random-uuid.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
+++ b/.github/workflows/release-trendmicro-cloudonecontainer-helm.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-unxpose-iam-integration-module.yml
+++ b/.github/workflows/release-unxpose-iam-integration-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
+++ b/.github/workflows/release-zmk-iam-lambdabasicrole-module.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
           overwrite: true
     container:
-      image: jsii/superchain:1-bullseye-slim
+      image: jsii/superchain:1-bullseye-slim-node20
   release_github:
     name: Publish to GitHub Releases
     needs:

--- a/projenrc/generate-packages.ts
+++ b/projenrc/generate-packages.ts
@@ -5,7 +5,7 @@ import { typescript } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
 import { CloudFormationTypeProject } from './type-package';
 
-const JSII_VERSION = '1-bullseye-slim';
+const JSII_VERSION = '1-bullseye-slim-node20';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const deprecations = require('../deprecated-types.json');

--- a/projenrc/type-package.ts
+++ b/projenrc/type-package.ts
@@ -10,7 +10,7 @@ import { JobPermission } from 'projen/lib/github/workflows-model';
 import { Publisher } from 'projen/lib/release';
 import { Readme } from './readme';
 
-const JSII_VERSION = '1-bullseye-slim';
+const JSII_VERSION = '1-bullseye-slim-node20';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const CDK_VERSION = require('aws-cdk-lib/package.json').version;


### PR DESCRIPTION
Releasing this repository is currently broken.

`@aws-cdk/cloud-assembly-schema` accidentally advertises that it needs node `18.18` or higher to work; Superchain currently vends node `18.17`, and it's hard to release Superchain.

Because of the way our package is versioned and released, the version constraint is not easy to fix.

It's easier to switch to a Node 20 version of Superchain, which is definitely higher than `18.18`, to unblock the releases.

Fixes #