### PR TITLE
chore: fix update-registry workflow fails to create PR

### DIFF
--- a/.github/workflows/update-registry.yml
+++ b/.github/workflows/update-registry.yml
@@ -20,15 +20,35 @@ jobs:
           role-session-name: github-automation
       - run: yarn install
       - run: npx projen update-registry
-      - id: create-pr
-        uses: peter-evans/create-pull-request@v4
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-          title: "feat: cloudformation registry update"
-          commit-message: "feat: cloudformation registry update"
+          commit-message: |-
+            feat: cloudformation registry update
+
+            This PR was automatically created by a GitHub Action. See details in [workflow run].
+
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ------
+
+            *Automatically created by projen via the "update-registry" workflow*
           branch: automation/update-registry
-          committer: GitHub Automation <noreply@github.com>
+          title: "feat: cloudformation registry update"
           labels: auto-approve
+          body: |-
+            This PR was automatically created by a GitHub Action. See details in [workflow run].
+
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ------
+
+            *Automatically created by projen via the "update-registry" workflow*
+          author: GitHub Automation <noreply@github.com>
+          committer: GitHub Automation <noreply@github.com>
+          signoff: true
       - if: steps.create-pr.outputs.pull-request-number != 0
         uses: peter-evans/enable-pull-request-automerge@v2
         with:

--- a/projenrc/update-registry.ts
+++ b/projenrc/update-registry.ts
@@ -1,6 +1,6 @@
 import { GithubActionsIdentityProvider, GithubActionsRole } from 'aws-cdk-github-oidc';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Component, typescript } from 'projen';
+import { Component, typescript, github } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
 import { AwsInfrastructure } from './aws-infrastructure';
 
@@ -62,18 +62,21 @@ export class UpdateRegistry extends Component {
           { run: this.project.runTaskCommand(task) },
 
           // create a pull request
-          {
-            uses: 'peter-evans/create-pull-request@v4',
-            id: 'create-pr',
-            with: {
-              'token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',
-              'title': 'feat: cloudformation registry update',
-              'commit-message': 'feat: cloudformation registry update',
-              'branch': 'automation/update-registry',
-              'committer': 'GitHub Automation <noreply@github.com>',
-              'labels': 'auto-approve',
+          ...github.WorkflowActions.createPullRequest({
+            workflowName: workflow.name,
+            stepId: 'create-pr',
+            branchName: 'automation/update-registry',
+            pullRequestTitle: 'feat: cloudformation registry update',
+            pullRequestDescription: 'This PR was automatically created by a GitHub Action',
+            labels: ['auto-approve'],
+            credentials: github.GithubCredentials.fromPersonalAccessToken({
+              secret: 'PROJEN_GITHUB_TOKEN',
+            }),
+            gitIdentity: {
+              name: 'GitHub Automation',
+              email: 'noreply@github.com',
             },
-          },
+          }),
 
           // Auto-approve PR
           {


### PR DESCRIPTION
The action `peter-evans/create-pull-request` used to create the PR was using an outdated version. Instead switch to the projen provided version which will be automatically updated.